### PR TITLE
fix linting with unused library; add pkgx setup option

### DIFF
--- a/nrapp/README.md
+++ b/nrapp/README.md
@@ -2,7 +2,19 @@
 
 This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
 
-## Get started
+## Setup
+
+### Alternative 1: pkgx - per session
+
+Here's a quick way to set up each session:
+
+```
+sh <(curl https://pkgx.sh) +pnpm.io +watchman sh
+```
+
+(We recommend installing pkgx from [pkgx.dev](https://pkgx.sh/) for extra speed & goodies, but it's optional.)
+
+### Alternative 2: manual - global & permanent
 
 1. Install watchman (or equivalent on *nix)
 
@@ -28,11 +40,11 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    pnpm install
    ```
 
-5. Start the app
+## Start
 
-   ```bash
-   pnpm start
-   ```
+```bash
+pnpm start
+```
 
 (If you get a `too many open files` error, `rm -rf node_modules; npm install` will [fix](https://github.com/Trustroots/nostroots/issues/30) this, funny enough.)
 

--- a/nrapp/index.ts
+++ b/nrapp/index.ts
@@ -1,7 +1,6 @@
 /* eslint-disable import/first */
 // import "polyfill"
 import { getRandomValues } from "expo-crypto";
-import "fast-text-encoding";
 import "./MessageChannel.js";
 
 // Patch `crypto.getRandomValues()` for `nip06` which depends on `@scure/bip32`


### PR DESCRIPTION

* fix linting (because it doesn't currently pass git precommit hooks... but if this library is used we might need to install iit)

* add pkgx setup instructions as an option

