### PR TITLE
Issue76 enforcing note length

### DIFF
--- a/nr-app/src/components/AddNoteForm.tsx
+++ b/nr-app/src/components/AddNoteForm.tsx
@@ -52,7 +52,7 @@ export default function AddNoteForm() {
           );
         }
 
-        // validate note content. Must be longer than 3 chars (https://github.com/Trustroots/nostroots/issues/76)
+        // validate note content. Must be longer than 3 chars
         if (noteContent.trim().length < 3) {
           Toast.show("Note must be at least 3 characters long", {
             duration: Toast.durations.LONG,


### PR DESCRIPTION
Issue: notes with 1–2 characters were being accepted but not displayed
https://github.com/Trustroots/nostroots/issues/76

Change: enforced a minimum length of 3 characters client-side. 
Closes #76

