### PR TITLE
Kind 1 events exclusion

### DIFF
--- a/nr-web/src/app/list/page.tsx
+++ b/nr-web/src/app/list/page.tsx
@@ -7,8 +7,11 @@ export default function ListPage() {
   const events = useNostrStore((state) => state.events);
   const connectionStatus = useNostrStore((state) => state.connectionStatus);
 
+  // Filter out kind 1 events (text notes/replies) from the list view
+  const filteredEvents = events.filter((event) => event.kind !== 1);
+
   // Group events by kind
-  const groupedEvents = events.reduce(
+  const groupedEvents = filteredEvents.reduce(
     (acc, event) => {
       const kind = event.kind.toString();
       if (!acc[kind]) {
@@ -66,7 +69,7 @@ export default function ListPage() {
 
       <div className="mb-4 p-4 bg-trustroots/10 rounded-lg">
         <p className="text-lg font-medium text-trustroots-dark">
-          Total: {events.length} events
+          Total: {filteredEvents.length} events
         </p>
       </div>
 
@@ -122,7 +125,7 @@ export default function ListPage() {
         </div>
       ))}
 
-      {events.length === 0 && (
+      {filteredEvents.length === 0 && (
         <div className="text-center py-12 text-gray-500">
           <p>No events yet. Waiting for data from relay...</p>
         </div>


### PR DESCRIPTION
Exclude kind 1 events from the list view to align with map view filtering.

Kind 1 events (text notes/replies) are used for replies in the `EventDetailModal` but should not be displayed in the main list or map views. The map view already filtered these events, and this PR applies the same filtering to the list view for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5f59c18-d311-4638-98d4-7919f1e05c1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a5f59c18-d311-4638-98d4-7919f1e05c1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns list view with map view by hiding text note/reply events.
> 
> - Filters out `kind !== 1` into `filteredEvents` in `nr-web/src/app/list/page.tsx`
> - Groups by kind using `filteredEvents` and updates the displayed total/counts
> - Uses `filteredEvents.length` for the empty-state rendering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a9f48321e3d8b4ceaed2595704c80b4e114e074. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->