### PR TITLE
Feature/5strfry

### DIFF
--- a/5strfry/.gitignore
+++ b/5strfry/.gitignore
@@ -1,0 +1,6 @@
+# Allowlist is populated at runtime; do not commit
+allowlist/allowlist.json
+
+# Ignore LMDB database files (runtime data)
+strfry-db/*.mdb
+strfry-db/lock.mdb

--- a/5strfry/Dockerfile
+++ b/5strfry/Dockerfile
@@ -1,0 +1,11 @@
+# Stage 1: compile the write-policy plugin to a standalone binary (no Deno in final image)
+FROM denoland/deno:alpine AS deno-stage
+WORKDIR /plugin
+COPY plugin/main.ts plugin/deno.json ./
+RUN deno compile -A -o nip5-policy main.ts
+
+# Stage 2: strfry with only the compiled plugin binary
+FROM thesamecat/strfry:latest
+COPY --from=deno-stage /plugin/nip5-policy /app/plugin/nip5-policy
+COPY plugin/run.sh /app/plugin/run.sh
+RUN chmod +x /app/plugin/nip5-policy /app/plugin/run.sh

--- a/5strfry/README.md
+++ b/5strfry/README.md
@@ -1,0 +1,64 @@
+# 5strfry
+
+Strfry relay with a **NIP-5 write policy**: only events from Trustroots NIP-05 verified pubkeys are accepted, except **kind 0** (metadata), which is accepted from anyone so users can set their profile and NIP-05.
+
+## How it works
+
+- **Kind 0:** Always accepted. If the event’s `content` (JSON) has a `nip05` field ending with `@trustroots.org`, that event’s `pubkey` is added to an allowlist.
+- **All other kinds:** Accepted only if the event’s `pubkey` is in the allowlist (i.e. they previously published a kind 0 with Trustroots NIP-05 on this relay).
+
+The allowlist is stored in `allowlist/allowlist.json` and is not committed to git.
+
+## Run
+
+From this directory:
+
+```bash
+chmod +x plugin/run.sh
+docker compose up -d
+```
+
+Relay URL: `ws://localhost:7777`.
+
+## Connecting from nr-web
+
+1. **Start 5strfry:** `docker compose up -d` in this directory (so the relay is listening on port 7777).
+2. In nr-web (e.g. http://localhost:8765), open **Settings** and add relay URL **`ws://localhost:7777`** (must start with `ws://` or `wss://`, not `http://` or plain `localhost:7777`).
+3. If it still fails to connect: check the browser devtools **Console** for the error; ensure nothing else is using port 7777; try `ws://127.0.0.1:7777` instead of `ws://localhost:7777`.
+
+## Deployment
+
+Deployed on the wiki server at **5str.nomadwiki.org** (wss://5str.nomadwiki.org).
+
+## Test
+
+1. Connect a Nostr client to `ws://localhost:7777`.
+2. Publish a kind 0 (set metadata) with `nip05` set to e.g. `yourname@trustroots.org`; it will be accepted and your pubkey will be added to the allowlist.
+3. Publish other kinds (e.g. kind 1 notes); they will be accepted only if your pubkey is already on the allowlist.
+
+## Configuration
+
+- **ALLOWLIST_PATH** (env): Path to the allowlist JSON file inside the container (default: `/app/allowlist/allowlist.json`).
+- **TRUSTROOTS_NIP05_DOMAIN** (env): NIP-05 domain suffix (default: `trustroots.org`). The plugin accepts `nip05` values ending with `@<this value>`.
+
+Set in `docker-compose.yml` under the `strfry` service `environment`.
+
+## Base image
+
+The Dockerfile uses `thesamecat/strfry:latest` and compiles the NIP-5 plugin to a standalone binary (no Deno in the final image). If that image is unavailable, change the Dockerfile to use e.g. `ghcr.io/trustroots/strfry:master` and install Deno in the image (e.g. with `apt-get` or by copying the Deno binary from a `denoland/deno` stage).
+
+## AMD64 vs ARM (Apple Silicon)
+
+The Compose file sets **`platform: linux/amd64`** so the image matches the strfry base and runs on typical Linux servers (e.g. the deployment host).
+
+**On Apple Silicon (ARM) Macs:**
+
+- Docker runs the amd64 image via emulation (Rosetta). The write-policy plugin is a compiled amd64 binary; it can fail inside the container with:
+  - `exec: /app/plugin/nip5-policy: not found`, or
+  - `rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2`
+- When the plugin fails, strfry reports **`error: internal error`** for every write and events are rejected.
+
+**What to do:**
+
+- **Production / deployment:** Build and run on an **amd64 Linux** host (e.g. the wiki server). The same image works there.
+- **Local testing on ARM Mac:** Either test against the deployed relay (wss://5str.nomadwiki.org), or build and run 5strfry on an amd64 machine/VM. Removing `platform: linux/amd64` and building natively produces an ARM binary, but the strfry base image is amd64-only, so the plugin would still not run inside the container.

--- a/5strfry/docker-compose.yml
+++ b/5strfry/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  strfry:
+    build: .
+    platform: linux/amd64
+    container_name: 5strfry
+    environment:
+      ALLOWLIST_PATH: /app/allowlist/allowlist.json
+      TRUSTROOTS_NIP05_DOMAIN: trustroots.org
+    volumes:
+      - ./strfry.conf:/app/strfry.conf
+      - ./strfry-db:/app/strfry-db
+      - ./allowlist:/app/allowlist
+    ports:
+      - "7777:7777"
+    working_dir: /app

--- a/5strfry/plugin/deno.json
+++ b/5strfry/plugin/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@std/streams": "jsr:@std/streams@^1.0.0"
+  }
+}

--- a/5strfry/plugin/main.ts
+++ b/5strfry/plugin/main.ts
@@ -1,0 +1,101 @@
+/**
+ * Strfry write-policy plugin: allow kind 0 from anyone; other kinds only from
+ * pubkeys that have set nip05 to *@trustroots.org in a kind 0 (allowlist built
+ * from kind 0 events and persisted to ALLOWLIST_PATH).
+ */
+import { TextLineStream } from "jsr:@std/streams";
+
+const ALLOWLIST_PATH = Deno.env.get("ALLOWLIST_PATH") ?? "./allowlist.json";
+const NIP05_SUFFIX = (Deno.env.get("TRUSTROOTS_NIP05_DOMAIN") ?? "trustroots.org")
+  .toLowerCase()
+  .replace(/^@+/, "");
+const NIP05_SUFFIX_AT = `@${NIP05_SUFFIX}`;
+
+const REJECT_MSG = "Only Trustroots NIP-05 verified users can post";
+
+type StrfryInput = {
+  type: string;
+  event: { id: string; pubkey: string; kind: number; content: string };
+};
+
+function loadAllowlist(): Set<string> {
+  try {
+    const data = Deno.readTextFileSync(ALLOWLIST_PATH);
+    const parsed = JSON.parse(data) as { pubkeys?: string[] };
+    return new Set(parsed.pubkeys ?? []);
+  } catch {
+    return new Set();
+  }
+}
+
+function saveAllowlist(pubkeys: Set<string>): void {
+  const dir = ALLOWLIST_PATH.replace(/\/[^/]+$/, "");
+  try {
+    Deno.mkdirSync(dir, { recursive: true });
+  } catch {
+    // dir exists or path has no dir
+  }
+  Deno.writeTextFileSync(
+    ALLOWLIST_PATH,
+    JSON.stringify({ pubkeys: [...pubkeys].sort() }) + "\n"
+  );
+}
+
+function hasTrustrootsNip05(content: string): boolean {
+  let profile: { nip05?: string };
+  try {
+    profile = JSON.parse(content) as { nip05?: string };
+  } catch {
+    return false;
+  }
+  const nip05 = typeof profile.nip05 === "string" ? profile.nip05.trim() : "";
+  if (!nip05) return false;
+  return nip05.toLowerCase().endsWith(NIP05_SUFFIX_AT);
+}
+
+const encoder = new TextEncoder();
+
+function respond(id: string, action: "accept" | "reject", msg?: string): void {
+  const out: { id: string; action: "accept" | "reject"; msg?: string } = {
+    id,
+    action,
+  };
+  if (action === "reject" && msg !== undefined) out.msg = msg;
+  const line = JSON.stringify(out) + "\n";
+  Deno.stdout.writeSync(encoder.encode(line));
+}
+
+let allowlist = loadAllowlist();
+
+const stdin = Deno.stdin.readable
+  .pipeThrough(new TextDecoderStream())
+  .pipeThrough(new TextLineStream());
+
+for await (const line of stdin) {
+  if (line.trim() === "") continue;
+  let input: StrfryInput;
+  try {
+    input = JSON.parse(line) as StrfryInput;
+  } catch {
+    continue;
+  }
+  if (input.type !== "new" || !input.event?.id) {
+    continue;
+  }
+  const { id, pubkey, kind, content } = input.event;
+
+  if (kind === 0) {
+    respond(id, "accept");
+    if (hasTrustrootsNip05(content) && !allowlist.has(pubkey)) {
+      allowlist.add(pubkey);
+      saveAllowlist(allowlist);
+    }
+    continue;
+  }
+
+  if (allowlist.has(pubkey)) {
+    respond(id, "accept");
+  } else {
+    respond(id, "reject", REJECT_MSG);
+  }
+}

--- a/5strfry/plugin/run.sh
+++ b/5strfry/plugin/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# ALLOWLIST_PATH and TRUSTROOTS_NIP05_DOMAIN are set by docker-compose.
+exec /app/plugin/nip5-policy

--- a/5strfry/strfry.conf
+++ b/5strfry/strfry.conf
@@ -1,0 +1,76 @@
+##
+## 5strfry: Trustroots NIP-5 write policy
+## Paths are container paths; Compose mounts repo dirs into /app
+##
+
+# Directory that contains the strfry LMDB database (restart required)
+db = "/app/strfry-db/"
+
+dbParams {
+    maxreaders = 256
+    mapsize = 10995116277760
+    noReadAhead = false
+}
+
+events {
+    maxEventSize = 65536
+    rejectEventsNewerThanSeconds = 900
+    rejectEventsOlderThanSeconds = 94608000
+    rejectEphemeralEventsOlderThanSeconds = 60
+    ephemeralEventsLifetimeSeconds = 300
+    maxNumTags = 2000
+    maxTagValSize = 1024
+}
+
+relay {
+    bind = "0.0.0.0"
+    port = 7777
+    nofiles = 1000000
+    realIpHeader = ""
+
+    info {
+        name = "Trustroots strfry (NIP-5)"
+        description = "Accepts kind 0 from anyone; other kinds only from Trustroots NIP-05 verified pubkeys."
+        pubkey = ""
+        contact = ""
+        icon = ""
+        nips = ""
+    }
+
+    maxWebsocketPayloadSize = 131072
+    maxReqFilterSize = 200
+    autoPingSeconds = 55
+    enableTcpKeepalive = false
+    queryTimesliceBudgetMicroseconds = 10000
+    maxFilterLimit = 500
+    maxSubsPerConnection = 20
+
+    writePolicy {
+        plugin = "/app/plugin/run.sh"
+    }
+
+    compression {
+        enabled = true
+        slidingWindow = true
+    }
+
+    logging {
+        dumpInAll = false
+        dumpInEvents = false
+        dumpInReqs = false
+        dbScanPerf = false
+        invalidEvents = true
+    }
+
+    numThreads {
+        ingester = 3
+        reqWorker = 3
+        reqMonitor = 3
+        negentropy = 2
+    }
+
+    negentropy {
+        enabled = true
+        maxSyncEvents = 1000000
+    }
+}

--- a/nr-push/strfry/backup-strfry.sh
+++ b/nr-push/strfry/backup-strfry.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+CONTAINER_NAME="${STRFRY_CONTAINER:-nostroots-server-strfry-nostr-relay-1}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKUP_FILE="${SCRIPT_DIR}/backups/strfry-backup-$(date +%Y%m%d-%H%M%S).jsonl"
+
+mkdir -p "${SCRIPT_DIR}/backups"
+
+echo "Stopping container..."
+docker stop "${CONTAINER_NAME}" || true
+
+echo "Exporting database..."
+docker run --rm \
+  -v "${SCRIPT_DIR}/strfry.conf:/etc/strfry.conf:ro" \
+  -v "${SCRIPT_DIR}/strfry-db:/app/strfry-db:ro" \
+  ghcr.io/trustroots/strfry:master \
+  export > "${BACKUP_FILE}"
+
+echo "Starting container..."
+docker start "${CONTAINER_NAME}"
+
+echo "Backup saved to: ${BACKUP_FILE}"

--- a/nr-web/Dockerfile
+++ b/nr-web/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20-slim
 
-WORKDIR /app
+WORKDIR /app/nr-web
 
 # Install system dependencies for Playwright
 RUN apt-get update && apt-get install -y \
@@ -23,29 +23,17 @@ RUN apt-get update && apt-get install -y \
 # Install pnpm
 RUN npm install -g pnpm
 
-# Copy package files from monorepo root
-COPY package.json pnpm-lock.yaml* ./
-COPY pnpm-workspace.yaml ./
+# Copy nr-web package.json and install dependencies directly (not as workspace)
+COPY nr-web/package.json ./
 
-# Copy nr-web package.json
-COPY nr-web/package.json ./nr-web/
-
-# Install dependencies
-# Skip postinstall scripts since patch-package is for nr-app, not nr-web tests
-# If lockfile is outdated, it will be updated during install
-# In CI environments, ensure lockfile is up to date before building
-RUN pnpm install --frozen-lockfile --ignore-scripts || ( \
-      echo "⚠️  Lockfile outdated. Updating..." && \
-      pnpm install --no-frozen-lockfile --ignore-scripts \
-    )
+# Install dependencies directly in nr-web (not as pnpm workspace)
+RUN pnpm install --ignore-scripts
 
 # Install Playwright browsers (Chromium only for smaller image)
-RUN cd nr-web && npx playwright install chromium --with-deps
+RUN npx playwright install chromium --with-deps
 
 # Copy test files and source (will be overridden by volume mount in docker-compose)
-COPY nr-web/ ./nr-web/
-
-WORKDIR /app/nr-web
+COPY nr-web/ ./
 
 # Default command runs all tests
 CMD ["pnpm", "test:local:all"]

--- a/nr-web/docker-compose.yml
+++ b/nr-web/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: nr-web/Dockerfile
     volumes:
       # Mount source code for development (allows code changes without rebuild)
-      - ../nr-web:/app/nr-web
+      - .:/app/nr-web
       # Mount node_modules from container to avoid permission issues
       - test-node-modules:/app/nr-web/node_modules
     working_dir: /app/nr-web

--- a/nr-web/example.env
+++ b/nr-web/example.env
@@ -1,0 +1,11 @@
+# Test account credentials for automated publishing tests
+# Copy this file to .env and fill in the values
+
+# Nostr private key in nsec format (e.g., nsec1...)
+# This key will be used to sign and publish test events
+TEST_NSEC=
+
+# Trustroots username for the test account
+# This username should be linked to the pubkey derived from TEST_NSEC
+# The test will verify NIP-5 validation before publishing
+TEST_TRUSTROOTS_USERNAME=

--- a/nr-web/index.html
+++ b/nr-web/index.html
@@ -270,6 +270,36 @@
             transform: scale(0.95);
         }
         
+        /* Floating Keys Button */
+        .keys-icon {
+            position: fixed;
+            top: 20px;
+            right: 86px;
+            width: 56px;
+            height: 56px;
+            border-radius: 50%;
+            background: var(--primary);
+            color: var(--primary-foreground);
+            border: none;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.5rem;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+            z-index: 1000;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        
+        .keys-icon:hover {
+            transform: scale(1.1);
+            box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+        }
+        
+        .keys-icon:active {
+            transform: scale(0.95);
+        }
+        
         .settings-section {
             background: var(--card);
             padding: 1.25rem;
@@ -411,14 +441,16 @@
         }
         
         .nip07-status {
-            font-size: 0.8125rem;
-            padding: 0.5rem 0.75rem;
+            font-size: 0.75rem;
+            padding: 0.375rem 0.625rem;
             border-radius: calc(var(--radius) - 2px);
             margin-top: 0.75rem;
+            margin-bottom: 0;
             display: none;
             background: hsla(167, 81.9%, 39%, 0.1);
             color: var(--primary);
             border: 1px solid hsla(167, 81.9%, 39%, 0.2);
+            line-height: 1.4;
         }
         
         .nip07-status.show {
@@ -430,6 +462,34 @@
             color: var(--muted-foreground);
             margin-top: 0.5rem;
             font-style: italic;
+        }
+        
+        .keys-option-section {
+            margin-bottom: 1.5rem;
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            background: var(--card);
+            padding: 1.25rem;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+        
+        .keys-option-section:hover {
+            border-color: var(--primary);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+        
+        .keys-option-content {
+            display: flex;
+            flex-direction: column;
+        }
+        
+        .keys-option-description {
+            font-size: 0.8125rem;
+            color: var(--muted-foreground);
+            margin-top: 0.75rem;
+            margin-bottom: 0;
+            text-align: center;
+            line-height: 1.5;
         }
         
         .action-buttons {
@@ -1055,6 +1115,11 @@
             background: var(--primary);
             color: var(--primary-foreground);
         }
+        
+        .status-event-actions { margin-top: 0.5rem; display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+        .status-event-actions button { padding: 0.25rem 0.5rem; font-size: 0.8rem; cursor: pointer; border: 1px solid rgba(255,255,255,0.5); background: rgba(255,255,255,0.15); color: inherit; border-radius: 4px; }
+        .status-event-actions button:hover { background: rgba(255,255,255,0.25); }
+        .status-event-pre { margin-top: 0.5rem; padding: 0.5rem; background: rgba(0,0,0,0.2); border-radius: 4px; font-size: 0.7rem; white-space: pre-wrap; word-break: break-all; max-height: 12rem; overflow: auto; text-align: left; }
     </style>
 </head>
 <body>
@@ -1069,28 +1134,6 @@
     
     
     <!-- Modals -->
-    <div class="modal" id="onboarding-modal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h2>Welcome to Nostroots</h2>
-            </div>
-            <p>You need a nostr key to get started. <strong>Recommended:</strong> Use a browser extension (your private key stays secure in the extension).</p>
-            <div class="form-group" id="onboarding-nip07-section" style="display: none;">
-                <button class="btn" onclick="onboardingConnectExtension()" style="width: 100%; margin-bottom: 0.5rem;">Connect Browser Extension (nos2x, Alby)</button>
-                <p style="font-size: 0.75rem; color: var(--muted-foreground); margin-top: 0.5rem; text-align: center;">
-                    Your private key never leaves the extension
-                </p>
-            </div>
-            <div style="text-align: center; margin: 1rem 0; color: var(--muted-foreground);">or</div>
-            <div class="form-group">
-                <label>Import nsec (optional)</label>
-                <input type="text" id="onboarding-nsec" placeholder="nsec1...">
-            </div>
-            <button class="btn" onclick="onboardingGenerate()">Generate New Key</button>
-            <button class="btn btn-secondary" onclick="onboardingImport()">Import nsec</button>
-        </div>
-    </div>
-    
     <div class="modal" id="view-note-modal">
         <div class="modal-content">
             <div class="modal-header">
@@ -1153,18 +1196,62 @@
     <!-- Status Messages Container -->
     <div id="status-container" class="status-container"></div>
     
+    <!-- Floating Keys Button -->
+    <button class="keys-icon" id="keys-icon-btn" title="Keys">🔑</button>
+    
     <!-- Floating Settings Button -->
     <button class="settings-icon" id="settings-icon-btn" title="Settings">⚙️</button>
     
-    <!-- Settings Modal -->
-    <div class="modal" id="settings-modal">
+    <!-- Keys Modal -->
+    <div class="modal" id="keys-modal">
         <div class="modal-content">
             <div class="modal-header">
-                <h2>Settings</h2>
-                <button class="modal-close" onclick="closeSettingsModal()">&times;</button>
-            </div>
-            <div class="settings-section">
                 <h2>Keys</h2>
+                <button class="modal-close" id="keys-modal-close-btn" onclick="closeKeysModal()">&times;</button>
+            </div>
+            
+            <!-- Welcome message (only shown when no key is set) -->
+            <div id="keys-welcome-section" style="display: none; margin-bottom: 2rem;">
+                <h2 style="margin-bottom: 0.5rem;">Welcome to Nostroots</h2>
+                <p style="color: var(--muted-foreground); margin: 0;">You need a nostr key to get started. Choose one of the options below:</p>
+            </div>
+            
+            <!-- Option 1: NIP-07 Browser Extension (only shown when no key) -->
+            <div class="keys-option-section" id="keys-nip07-section" style="display: none;">
+                <div class="keys-option-content">
+                    <button class="btn" onclick="onboardingConnectExtension()" style="width: 100%;">Connect Browser Extension (NIP-07)</button>
+                    <p class="keys-option-description">
+                        Your private key never leaves the extension (nos2x, Alby)
+                    </p>
+                </div>
+            </div>
+            
+            <!-- Option 2: Import nsec or mnemonic (only shown when no key) -->
+            <div class="keys-option-section" id="keys-import-section" style="display: none;">
+                <div class="keys-option-content">
+                    <textarea id="onboarding-import" placeholder="Enter nsec1... or mnemonic phrase (12 or 24 words)..." style="width: 100%; min-height: 80px; margin-bottom: 0.75rem; font-family: monospace; resize: vertical; padding: 0.75rem; border: 1px solid var(--border); border-radius: calc(var(--radius) - 2px); background: var(--input); color: var(--foreground);"></textarea>
+                    <button class="btn btn-secondary" onclick="onboardingImport()" style="width: 100%;">Import</button>
+                </div>
+            </div>
+            
+            <!-- Option 3: Generate New Key (only shown when no key) -->
+            <div class="keys-option-section" id="keys-generate-section" style="display: none;">
+                <div class="keys-option-content">
+                    <button class="btn" onclick="onboardingGenerate()" style="width: 100%;">Generate New Key</button>
+                </div>
+            </div>
+            
+            <!-- Keys section (only shown when key is set) -->
+            <div class="settings-section" id="keys-manage-section" style="display: none;">
+                <h2>Keys</h2>
+                
+                <!-- Local Key Actions (above npub) -->
+                <div class="form-group" id="nsec-actions-group" style="display: none;">
+                    <div class="action-buttons">
+                        <button class="btn" onclick="exportNsec()">Export nsec</button>
+                        <button class="btn btn-danger" onclick="deleteNsec()">Delete Key</button>
+                    </div>
+                </div>
                 
                 <!-- Public Key Display -->
                 <div class="form-group" id="npub-display-group" style="display: none;">
@@ -1182,12 +1269,12 @@
                 <!-- NIP-07 Status Indicator -->
                 <div id="nip07-status" class="nip07-status"></div>
                 
-                <!-- Local Key Actions -->
-                <div class="form-group" id="nsec-actions-group" style="display: none;">
-                    <div class="action-buttons">
-                        <button class="btn" onclick="exportNsec()">Export nsec</button>
-                        <button class="btn btn-danger" onclick="deleteNsec()">Delete Key</button>
-                    </div>
+                <!-- Update Trustroots Profile button (below NIP-07 status) -->
+                <div class="form-group" id="update-trustroots-profile-group" style="display: none; margin-top: 0.75rem;">
+                    <button class="btn btn-secondary" onclick="updateTrustrootsProfile()" style="width: 100%;">
+                        <span style="margin-right: 0.5rem;">🌐</span>
+                        Update Trustroots Profile
+                    </button>
                 </div>
                 
                 <!-- Import/Generate Section -->
@@ -1202,17 +1289,26 @@
                 </div>
             </div>
             
-            <div class="settings-section">
+            <!-- Trustroots username section (only shown when key is set) -->
+            <div class="settings-section" id="keys-trustroots-section" style="display: none;">
                 <h2>Trustroots username</h2>
                 <div class="form-group">
                     <input type="text" id="trustroots-username" placeholder="your-username" onkeydown="if(event.key === 'Enter') linkTrustrootsProfile()">
                     <div id="username-nostr-indicator" class="username-nostr-indicator" style="display: none;">
                         <small>This username is from a Nostr event and cannot be edited here.</small>
                     </div>
-                    <button class="btn" id="link-profile-btn" onclick="linkTrustrootsProfile()">Link Profile</button>
                 </div>
             </div>
-            
+        </div>
+    </div>
+    
+    <!-- Settings Modal -->
+    <div class="modal" id="settings-modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2>Settings</h2>
+                <button class="modal-close" onclick="closeSettingsModal()">&times;</button>
+            </div>
             <div class="settings-section">
                 <h2>Relays</h2>
                 <div id="relays-list" class="relays-list"></div>
@@ -1260,6 +1356,9 @@
             Relay 
         } from 'https://cdn.jsdelivr.net/npm/nostr-tools@2.10.3/+esm';
         
+        // Import BIP39 for mnemonic support
+        import { mnemonicToSeedSync, validateMnemonic } from 'https://cdn.jsdelivr.net/npm/bip39@3.1.0/+esm';
+        
         // NDK is not loaded from CDN due to CORS/MIME type issues
         // We use nostr-tools Relay directly instead, which works reliably
         const NDK = null;
@@ -1273,6 +1372,47 @@
         const DEFAULT_RELAY_URL = 'wss://relay.trustroots.org';
         const DEFAULT_RELAYS = ['wss://relay.trustroots.org', 'wss://relay.nomadwiki.org'];
         const DERIVED_EVENT_PLUS_CODE_PREFIX_MINIMUM_LENGTH = 2;
+        
+        /** Normalize relay error message for display (e.g. "Error: error: internal error" -> "internal error"). */
+        function formatRelayError(errorStr) {
+            if (!errorStr || typeof errorStr !== 'string') return '';
+            const s = errorStr.replace(/^Error:\s*/i, '').trim();
+            return s.replace(/^error:\s*/i, '').trim() || s;
+        }
+        /** If any failure is a relay "internal error", return a short user hint. */
+        function getRelayPublishFailureHint(failed) {
+            const hasInternalError = failed.some(f => (f.error || '').toLowerCase().includes('internal error'));
+            return hasInternalError
+                ? ' Try again in a moment—relay errors are often temporary.'
+                : '';
+        }
+        
+        const RELAY_PUBLISH_RETRIES = 2;
+        const RELAY_PUBLISH_RETRY_DELAY_MS = 1500;
+        
+        /** Publish event to one relay with retries. Returns { success, url, error }. */
+        async function publishToRelayWithRetries(url, signedEvent) {
+            let lastError = null;
+            for (let attempt = 0; attempt <= RELAY_PUBLISH_RETRIES; attempt++) {
+                let relay = null;
+                try {
+                    relay = await Relay.connect(url);
+                    await relay.publish(signedEvent);
+                    await new Promise(resolve => setTimeout(resolve, 500));
+                    return { success: true, url };
+                } catch (error) {
+                    lastError = error?.message || String(error);
+                    if (attempt < RELAY_PUBLISH_RETRIES) {
+                        await new Promise(resolve => setTimeout(resolve, RELAY_PUBLISH_RETRY_DELAY_MS));
+                    }
+                } finally {
+                    if (relay) {
+                        try { relay.close(); } catch (_) {}
+                    }
+                }
+            }
+            return { success: false, url, error: lastError };
+        }
         
         const NOSTROOTS_VALIDATION_PUBKEY = 'f5bc71692fc08ea52c0d1c8bcfb87579584106b5feb4ea542b1b8a95612f257b';
         const DEV_PUBKEY = '80789235a71a388074abfa5c482e270456d2357425266270f82071cf2b1de74a';
@@ -1963,17 +2103,15 @@
                 // Check if extension is available
                 const provider = detectNostrExtension();
                 const nip07Section = document.getElementById('nip07-section');
-                const onboardingNip07Section = document.getElementById('onboarding-nip07-section');
+                // Note: onboarding-nip07-section is now always visible in the new UI, so we don't hide/show it
                 
                 if (provider) {
                     if (nip07Section) nip07Section.style.display = 'block';
-                    if (onboardingNip07Section) onboardingNip07Section.style.display = 'block';
                     
                     // Note: We don't auto-reconnect here to avoid conflicts with checkOnboarding()
                     // The checkOnboarding() function will handle reconnection if needed
                 } else {
                     if (nip07Section) nip07Section.style.display = 'none';
-                    if (onboardingNip07Section) onboardingNip07Section.style.display = 'none';
                     
                     // If extension was previously used but is now unavailable, clear preference
                     const wasUsingNip07 = localStorage.getItem('using_nip07') === 'true';
@@ -2165,7 +2303,7 @@
             showStatus('Private key deleted', 'success');
             
             // Show onboarding modal again
-            document.getElementById('onboarding-modal').classList.add('active');
+            openKeysModal();
         }
         
         function updateKeyDisplay() {
@@ -2174,8 +2312,8 @@
             const noNsecActionsGroup = document.getElementById('no-nsec-actions-group');
             const generateKeyBtn = document.getElementById('generate-key-btn');
             const generateKeyGroup = document.getElementById('generate-key-group');
-            const linkProfileBtn = document.getElementById('link-profile-btn');
             const nip07Status = document.getElementById('nip07-status');
+            const updateTrustrootsGroup = document.getElementById('update-trustroots-profile-group');
             
             if (usingNip07) {
                 // Using NIP-07 - hide nsec actions, show that we're using extension
@@ -2183,11 +2321,9 @@
                 if (nsecActionsGroup) nsecActionsGroup.style.display = 'none';
                 if (noNsecActionsGroup) noNsecActionsGroup.style.display = 'none';
                 if (generateKeyGroup) generateKeyGroup.style.display = 'none';
-                // Enable link profile button when using NIP-07 (extension provides signing)
-                if (linkProfileBtn) linkProfileBtn.disabled = false;
                 // Show NIP-07 status
                 if (nip07Status) {
-                    nip07Status.textContent = '✓ Using NIP-07 browser extension - private key secure in extension';
+                    nip07Status.textContent = '✓ Using NIP-07 extension - private key secure';
                     nip07Status.classList.add('show');
                 }
             } else {
@@ -2199,19 +2335,15 @@
                     if (nsecActionsGroup) nsecActionsGroup.style.display = 'block';
                     if (noNsecActionsGroup) noNsecActionsGroup.style.display = 'none';
                     if (generateKeyGroup) generateKeyGroup.style.display = 'none';
-                    // Enable link profile button when we have nsec
-                    if (linkProfileBtn) linkProfileBtn.disabled = false;
                 } else {
                     // Show import/generate buttons, hide export/delete
                     if (nsecActionsGroup) nsecActionsGroup.style.display = 'none';
                     if (noNsecActionsGroup) noNsecActionsGroup.style.display = 'block';
                     if (generateKeyGroup) generateKeyGroup.style.display = 'block';
-                    // Disable link profile button when there's no nsec
-                    if (linkProfileBtn) linkProfileBtn.disabled = true;
                 }
             }
             
-            // Show/hide public key field based on whether we have a public key
+            // Show/hide public key field and update button based on whether we have a public key
             const npubDisplayGroup = document.getElementById('npub-display-group');
             const keySectionDivider = document.getElementById('key-section-divider');
             
@@ -2222,11 +2354,15 @@
                     document.getElementById('npub-display').value = npub;
                     if (npubDisplayGroup) npubDisplayGroup.style.display = 'block';
                     if (keySectionDivider) keySectionDivider.style.display = 'block';
+                    // Only show update button if profile is not linked
+                    if (updateTrustrootsGroup) updateTrustrootsGroup.style.display = isProfileLinked ? 'none' : 'block';
                 } catch (error) {
                     console.error('Error encoding npub:', error);
                     document.getElementById('npub-display').value = 'Error encoding npub';
                     if (npubDisplayGroup) npubDisplayGroup.style.display = 'block';
                     if (keySectionDivider) keySectionDivider.style.display = 'block';
+                    // Only show update button if profile is not linked
+                    if (updateTrustrootsGroup) updateTrustrootsGroup.style.display = isProfileLinked ? 'none' : 'block';
                 }
                 // Check if profile is linked when public key changes
                 checkProfileLinked();
@@ -2234,6 +2370,7 @@
                 document.getElementById('npub-display').value = '';
                 if (npubDisplayGroup) npubDisplayGroup.style.display = 'none';
                 if (keySectionDivider) keySectionDivider.style.display = 'none';
+                if (updateTrustrootsGroup) updateTrustrootsGroup.style.display = 'none';
                 isProfileLinked = false;
                 updateLinkProfileButton();
             }
@@ -2313,16 +2450,19 @@
         
         function addRelay() {
             const input = document.getElementById('new-relay-url');
-            const url = input.value.trim();
+            let url = input.value.trim();
             
             if (!url) {
                 showStatus('Please enter a relay URL', 'error');
                 return;
             }
-            
+            // Normalize: if user entered host:port (e.g. localhost:7777), use ws:// so local relays work
             if (!url.startsWith('ws://') && !url.startsWith('wss://')) {
-                showStatus('Relay URL must start with ws:// or wss://', 'error');
-                return;
+                if (url.includes('://')) {
+                    showStatus('Relay URL must start with ws:// or wss://', 'error');
+                    return;
+                }
+                url = 'ws://' + url;
             }
             
             const urls = getRelayUrls();
@@ -4239,6 +4379,13 @@
                     tags: tags
                 };
                 
+                // Basic validation before signing
+                if (!eventTemplate.kind || !eventTemplate.content || !eventTemplate.tags || !Array.isArray(eventTemplate.tags)) {
+                    showStatus('Invalid event structure. Please try again.', 'error');
+                    console.error('Invalid event template:', eventTemplate);
+                    return;
+                }
+                
                 let signedEvent;
                 
                 // Sign event using NIP-07 extension or local key
@@ -4292,6 +4439,13 @@
                     signedEvent = finalizeEvent(eventTemplate, currentPrivateKeyBytes);
                 }
                 
+                // Validate signed event before publishing
+                if (!signedEvent || !signedEvent.id || !signedEvent.sig || !signedEvent.pubkey) {
+                    showStatus('Event signing failed. Please try again.', 'error');
+                    console.error('Invalid signed event:', signedEvent);
+                    return;
+                }
+                
                 // Publish to all configured relays (only those with Post enabled)
                 // Create new connections for each publish to avoid closed connection errors
                 const relayUrls = getRelayUrls().filter(url => relayWriteEnabled.get(url) !== false);
@@ -4301,48 +4455,10 @@
                     return;
                 }
                 
-                const publishPromises = relayUrls.map(async (url) => {
-                    let relay = null;
-                    try {
-                        relay = await Relay.connect(url);
-                        await relay.publish(signedEvent);
-                        // Wait a bit for the relay to process and confirm the event
-                        await new Promise(resolve => setTimeout(resolve, 500));
-                        return { success: true, url };
-                    } catch (error) {
-                        // Only log error if it's not a generic relay rejection
-                        const errorMessage = error?.message || String(error);
-                        if (!errorMessage.includes('relay experienced an error')) {
-                            console.error(`Error publishing to ${url}:`, error);
-                        }
-                        return { success: false, url, error: errorMessage };
-                    } finally {
-                        // Always close the relay connection, even if there was an error
-                        if (relay) {
-                            try {
-                                relay.close();
-                            } catch (closeError) {
-                                // Ignore errors when closing
-                            }
-                        }
-                    }
-                });
-                
-                const results = await Promise.allSettled(publishPromises);
-                const successful = [];
-                const failed = [];
-                
-                results.forEach((result, index) => {
-                    if (result.status === 'fulfilled') {
-                        if (result.value.success) {
-                            successful.push(result.value.url);
-                        } else {
-                            failed.push({ url: result.value.url, error: result.value.error });
-                        }
-                    } else {
-                        failed.push({ url: relayUrls[index], error: result.reason?.message || 'Unknown error' });
-                    }
-                });
+                const publishPromises = relayUrls.map(url => publishToRelayWithRetries(url, signedEvent));
+                const results = await Promise.all(publishPromises);
+                const successful = results.filter(r => r.success);
+                const failed = results.filter(r => !r.success).map(r => ({ url: r.url, error: r.error }));
                 
                 if (successful.length > 0) {
                     let statusMessage = `Note published to ${successful.length} relay(s)`;
@@ -4363,8 +4479,13 @@
                         showNotesForPlusCode(selectedPlusCode);
                     }, 100);
                 } else {
-                    const errorDetails = failed.map(f => `${new URL(f.url).hostname}`).join(', ');
-                    showStatus(`Failed to publish to all relays: ${errorDetails}`, 'error');
+                    const errorDetails = failed.map(f => {
+                        const hostname = new URL(f.url).hostname;
+                        const errorMsg = f.error ? ` (${formatRelayError(f.error)})` : '';
+                        return `${hostname}${errorMsg}`;
+                    }).join(', ');
+                    const hint = getRelayPublishFailureHint(failed);
+                    showStatus(`Failed to publish to all relays: ${errorDetails}.${hint}`, 'error', { eventPayload: signedEvent });
                 }
             } catch (error) {
                 console.error('Error publishing note:', error);
@@ -4825,13 +4946,19 @@
                         await new Promise(resolve => setTimeout(resolve, 500));
                         return { success: true, url };
                     } catch (error) {
-                        // For deletion events, we'll consider it successful if we sent it
-                        // even if we don't get a proper OK response
                         const errorMessage = error?.message || String(error);
-                        if (!errorMessage.includes('relay experienced an error')) {
-                            console.error(`Error publishing deletion to ${url}:`, error);
-                        }
-                        return { success: true, url }; // Consider deletion sent even on error
+                        console.error(`Error publishing deletion to ${url}:`, error);
+                        
+                        // For deletion events, we'll consider it successful if we sent it
+                        // even if we don't get a proper OK response (unless it's a clear rejection)
+                        const isClearRejection = errorMessage.includes('blocked') || 
+                                                errorMessage.includes('not allowed');
+                        
+                        return { 
+                            success: !isClearRejection, 
+                            url, 
+                            error: isClearRejection ? `Relay rejected: ${errorMessage}` : errorMessage 
+                        };
                     } finally {
                         if (relay) {
                             try {
@@ -4917,21 +5044,27 @@
             }
         }
         
-        function closeOnboardingModal() {
-            document.getElementById('onboarding-modal').classList.remove('active');
-        }
-        
         function closeActiveModal() {
             // Close any active modal
             const modals = document.querySelectorAll('.modal.active');
             modals.forEach(modal => {
-                if (modal.id === 'onboarding-modal') {
-                    // Don't allow closing onboarding modal with ESC (user must generate/import key)
-                    return;
+                if (modal.id === 'keys-modal') {
+                    // Don't allow closing keys modal with ESC when no key is set (user must generate/import key)
+                    const hasKey = !!(currentPublicKey || currentPrivateKey || usingNip07);
+                    if (!hasKey) {
+                        return;
+                    }
+                    closeKeysModal();
                 } else if (modal.id === 'view-note-modal') {
                     closeViewNoteModal();
                 } else if (modal.id === 'pluscode-notes-modal') {
                     closePlusCodeNotesModal();
+                } else if (modal.id === 'keys-modal') {
+                    // Don't allow closing keys modal with ESC when no key is set or profile not linked
+                    const hasKey = !!(currentPublicKey || currentPrivateKey || usingNip07);
+                    if (hasKey && isProfileLinked) {
+                        closeKeysModal();
+                    }
                 } else if (modal.id === 'settings-modal') {
                     closeSettingsModal();
                 } else {
@@ -4941,8 +5074,8 @@
             });
         }
         
-        function showStatus(message, type) {
-            // Get or create status container
+        function showStatus(message, type, options) {
+            options = options || {};
             let statusContainer = document.getElementById('status-container');
             if (!statusContainer) {
                 statusContainer = document.createElement('div');
@@ -4951,20 +5084,47 @@
                 document.body.appendChild(statusContainer);
             }
             
-            // Create status element
             const status = document.createElement('div');
             status.className = `status ${type}`;
-            status.textContent = message;
             
-            // Append to status container (will appear at top)
+            const msgEl = document.createElement('div');
+            msgEl.textContent = message;
+            status.appendChild(msgEl);
+            
+            if (options.eventPayload) {
+                const json = JSON.stringify(options.eventPayload, null, 2);
+                const actions = document.createElement('div');
+                actions.className = 'status-event-actions';
+                const copyBtn = document.createElement('button');
+                copyBtn.textContent = 'Copy event JSON';
+                copyBtn.type = 'button';
+                copyBtn.addEventListener('click', () => {
+                    navigator.clipboard.writeText(json).then(() => { copyBtn.textContent = 'Copied!'; setTimeout(() => { copyBtn.textContent = 'Copy event JSON'; }, 1500); }).catch(() => { copyBtn.textContent = 'Copy failed'; });
+                });
+                const showBtn = document.createElement('button');
+                showBtn.textContent = 'Show event data';
+                showBtn.type = 'button';
+                const pre = document.createElement('pre');
+                pre.className = 'status-event-pre';
+                pre.textContent = json;
+                pre.style.display = 'none';
+                showBtn.addEventListener('click', () => {
+                    const visible = pre.style.display !== 'none';
+                    pre.style.display = visible ? 'none' : 'block';
+                    showBtn.textContent = visible ? 'Show event data' : 'Hide event data';
+                });
+                actions.appendChild(copyBtn);
+                actions.appendChild(showBtn);
+                status.appendChild(actions);
+                status.appendChild(pre);
+            }
+            
             statusContainer.appendChild(status);
             
-            // Remove after 5 seconds
+            const hideMs = options.eventPayload ? 15000 : 5000;
             setTimeout(() => {
-                if (status.parentNode) {
-                    status.parentNode.removeChild(status);
-                }
-            }, 5000);
+                if (status.parentNode) status.parentNode.removeChild(status);
+            }, hideMs);
         }
         
         // Check if profile is linked (has kind 10390 event)
@@ -5103,6 +5263,18 @@
                 }
                 
                 updateLinkProfileButton();
+                
+                // Update close button visibility based on profile link status
+                const closeBtn = document.getElementById('keys-modal-close-btn');
+                if (closeBtn) {
+                    closeBtn.style.display = isProfileLinked ? 'block' : 'none';
+                }
+                
+                // Update "Update Trustroots Profile" button visibility - hide if profile is linked
+                const updateTrustrootsGroup = document.getElementById('update-trustroots-profile-group');
+                if (updateTrustrootsGroup) {
+                    updateTrustrootsGroup.style.display = isProfileLinked ? 'none' : 'block';
+                }
             } catch (error) {
                 console.error('Error checking profile link:', error);
                 isProfileLinked = false;
@@ -5119,28 +5291,102 @@
                 }
                 
                 updateLinkProfileButton();
+                
+                // Update close button visibility - hide if profile not linked
+                const closeBtn = document.getElementById('keys-modal-close-btn');
+                if (closeBtn) {
+                    closeBtn.style.display = 'none';
+                }
+                
+                // Show "Update Trustroots Profile" button if profile is not linked
+                const updateTrustrootsGroup = document.getElementById('update-trustroots-profile-group');
+                if (updateTrustrootsGroup && currentPublicKey) {
+                    updateTrustrootsGroup.style.display = 'block';
+                }
             }
         }
         
         // Update link profile button visibility
         function updateLinkProfileButton() {
-            const linkProfileBtn = document.getElementById('link-profile-btn');
-            if (linkProfileBtn) {
-                if (isProfileLinked) {
-                    linkProfileBtn.style.display = 'none';
-                } else {
-                    linkProfileBtn.style.display = 'block';
-                }
-            }
+            // Link Profile button has been removed, this function is kept for compatibility
+            // but no longer does anything
         }
         
         // Settings Modal Functions
+        function openKeysModal() {
+            document.getElementById('keys-modal').classList.add('active');
+            
+            // Check if we have a key
+            const hasKey = !!(currentPublicKey || currentPrivateKey || usingNip07);
+            
+            // Show welcome section and onboarding options when no key
+            const welcomeSection = document.getElementById('keys-welcome-section');
+            const nip07Section = document.getElementById('keys-nip07-section');
+            const importSection = document.getElementById('keys-import-section');
+            const generateSection = document.getElementById('keys-generate-section');
+            
+            // Show keys management section when key exists
+            const manageSection = document.getElementById('keys-manage-section');
+            const trustrootsSection = document.getElementById('keys-trustroots-section');
+            
+            // Get close button
+            const closeBtn = document.getElementById('keys-modal-close-btn');
+            
+            if (!hasKey) {
+                // No key - show welcome and onboarding options, hide close button
+                if (welcomeSection) welcomeSection.style.display = 'block';
+                if (importSection) importSection.style.display = 'block';
+                if (generateSection) generateSection.style.display = 'block';
+                if (manageSection) manageSection.style.display = 'none';
+                if (trustrootsSection) trustrootsSection.style.display = 'none';
+                if (closeBtn) closeBtn.style.display = 'none';
+                
+                // Check if NIP-07 extension is available and show the section
+                // Check immediately and also after a short delay to catch extensions that load late
+                const checkNip07 = () => {
+                    const provider = detectNostrExtension();
+                    if (nip07Section) {
+                        nip07Section.style.display = provider ? 'block' : 'none';
+                    }
+                };
+                
+                // Check immediately
+                checkNip07();
+                
+                // Also check after a short delay in case extension loads late
+                setTimeout(checkNip07, 300);
+            } else {
+                // Has key - show keys management and trustroots section
+                if (welcomeSection) welcomeSection.style.display = 'none';
+                if (nip07Section) nip07Section.style.display = 'none';
+                if (importSection) importSection.style.display = 'none';
+                if (generateSection) generateSection.style.display = 'none';
+                if (manageSection) manageSection.style.display = 'block';
+                if (trustrootsSection) trustrootsSection.style.display = 'block';
+                
+                // Update key display when opening keys modal
+                updateKeyDisplay();
+                // Check if profile is linked when opening keys modal
+                checkProfileLinked().then(() => {
+                    // Update close button visibility after checking profile link
+                    if (closeBtn) {
+                        closeBtn.style.display = isProfileLinked ? 'block' : 'none';
+                    }
+                });
+            }
+        }
+        
+        function closeKeysModal() {
+            // Don't allow closing if no key is set or if profile is not linked
+            const hasKey = !!(currentPublicKey || currentPrivateKey || usingNip07);
+            if (!hasKey || !isProfileLinked) {
+                return;
+            }
+            document.getElementById('keys-modal').classList.remove('active');
+        }
+        
         function openSettingsModal() {
             document.getElementById('settings-modal').classList.add('active');
-            // Check if profile is linked when opening settings
-            if (currentPublicKey) {
-                checkProfileLinked();
-            }
         }
         
         function closeSettingsModal() {
@@ -5148,8 +5394,12 @@
         }
         
         // Make functions globally accessible for onclick handlers
+        window.openKeysModal = openKeysModal;
+        window.closeKeysModal = closeKeysModal;
         window.openSettingsModal = openSettingsModal;
         window.closeSettingsModal = closeSettingsModal;
+        window.openKeysModal = openKeysModal;
+        window.closeKeysModal = closeKeysModal;
         window.saveExpirationSetting = saveExpirationSetting;
         window.addRelay = addRelay;
         window.removeRelay = removeRelay;
@@ -5176,7 +5426,7 @@
                                     nostrProvider = null;
                                     localStorage.removeItem('using_nip07');
                                     if (!hasKey) {
-                                        document.getElementById('onboarding-modal').classList.add('active');
+                                        openKeysModal();
                                         updateKeyDisplay();
                                     } else {
                                         loadKeys();
@@ -5188,7 +5438,7 @@
                                 nostrProvider = null;
                                 localStorage.removeItem('using_nip07');
                                 if (!hasKey) {
-                                    document.getElementById('onboarding-modal').classList.add('active');
+                                    openKeysModal();
                                     updateKeyDisplay();
                                 } else {
                                     loadKeys();
@@ -5204,7 +5454,7 @@
                         nostrProvider = null;
                         localStorage.removeItem('using_nip07');
                         if (!hasKey) {
-                            document.getElementById('onboarding-modal').classList.add('active');
+                            openKeysModal();
                             updateKeyDisplay();
                         } else {
                             loadKeys();
@@ -5215,7 +5465,7 @@
                 // Start reconnection attempt
                 tryReconnect();
             } else if (!hasKey) {
-                document.getElementById('onboarding-modal').classList.add('active');
+                openKeysModal();
                 // Ensure display is updated even when there's no key
                 updateKeyDisplay();
             } else {
@@ -5226,33 +5476,105 @@
         async function onboardingConnectExtension() {
             const success = await authenticateWithExtension();
             if (success) {
-                document.getElementById('onboarding-modal').classList.remove('active');
+                // Small delay to ensure state is updated before refreshing modal
+                await new Promise(resolve => setTimeout(resolve, 100));
+                // Refresh the keys modal to show the management section
+                openKeysModal();
                 showStatus('Connected via extension! Your private key is secure in the extension.', 'success');
             } else {
                 // authenticateWithExtension already shows specific error messages,
                 // so we don't need to show a generic one here
-                // The onboarding modal will remain open so user can try other options
+                // The keys modal will remain open so user can try other options
             }
         }
         
         function onboardingGenerate() {
             generateKeyPair();
-            document.getElementById('onboarding-modal').classList.remove('active');
+            // Refresh the keys modal to show the management section
+            openKeysModal();
         }
         
-        function onboardingImport() {
-            const nsec = document.getElementById('onboarding-nsec').value.trim();
-            if (nsec) {
-                const privateKeyHex = decodeNsec(nsec);
+        async function onboardingImport() {
+            const input = document.getElementById('onboarding-import').value.trim();
+            if (!input) {
+                showStatus('Please enter an nsec or mnemonic phrase', 'error');
+                return;
+            }
+            
+            // Detect if input is nsec (starts with nsec1) or mnemonic (multiple words)
+            if (input.startsWith('nsec1')) {
+                // Try to import as nsec
+                const privateKeyHex = decodeNsec(input);
                 if (privateKeyHex) {
                     savePrivateKey(privateKeyHex);
                     loadKeys();
-                    document.getElementById('onboarding-modal').classList.remove('active');
+                    // Refresh the keys modal to show the management section
+                    openKeysModal();
+                    showStatus('nsec imported successfully!', 'success');
                 } else {
                     showStatus('Invalid nsec', 'error');
                 }
             } else {
-                showStatus('Please enter an nsec', 'error');
+                // Try to import as mnemonic
+                try {
+                    // Validate mnemonic (using English wordlist by default)
+                    if (!validateMnemonic(input, wordlists.english)) {
+                        showStatus('Invalid mnemonic phrase. Please check your words.', 'error');
+                        return;
+                    }
+                    
+                    // Convert mnemonic to seed
+                    const seed = mnemonicToSeedSync(input);
+                    
+                    // For Nostr, we use the first 32 bytes of the seed as the private key
+                    // This is a common approach, though not standardized
+                    const privateKeyBytes = seed.slice(0, 32);
+                    const privateKeyHex = Array.from(privateKeyBytes)
+                        .map(b => b.toString(16).padStart(2, '0'))
+                        .join('');
+                    
+                    savePrivateKey(privateKeyHex);
+                    loadKeys();
+                    // Refresh the keys modal to show the management section
+                    openKeysModal();
+                    showStatus('Mnemonic imported successfully!', 'success');
+                } catch (error) {
+                    console.error('Error importing mnemonic:', error);
+                    showStatus('Error importing mnemonic: ' + (error.message || 'Unknown error'), 'error');
+                }
+            }
+        }
+        
+        // Update Trustroots Profile - copy npub and open Trustroots profile edit page
+        async function updateTrustrootsProfile() {
+            if (!currentPublicKey) {
+                showStatus('No public key available', 'error');
+                return;
+            }
+            
+            try {
+                // Get npub from display or generate it
+                const npubDisplay = document.getElementById('npub-display');
+                let npub;
+                
+                if (npubDisplay && npubDisplay.value) {
+                    npub = npubDisplay.value;
+                } else {
+                    // Generate npub if not in display
+                    npub = nip19.npubEncode(currentPublicKey);
+                }
+                
+                // Copy to clipboard
+                await navigator.clipboard.writeText(npub);
+                
+                // Show alert first
+                alert('Your npub has been copied to the clipboard. Please paste this npub into the Nostr field on Trustroots.');
+                
+                // Open Trustroots profile edit page in new tab
+                window.open('https://www.trustroots.org/profile/edit/networks', '_blank');
+            } catch (error) {
+                console.error('Error updating Trustroots profile:', error);
+                showStatus('Error copying public key: ' + (error.message || 'Unknown error'), 'error');
             }
         }
         
@@ -5321,48 +5643,10 @@
                             return;
                         }
                         
-                        const publishPromises = relayUrls.map(async (url) => {
-                            let relay = null;
-                            try {
-                                relay = await Relay.connect(url);
-                                await relay.publish(signedEvent);
-                                // Wait a bit for the relay to process and confirm the event
-                                await new Promise(resolve => setTimeout(resolve, 500));
-                                return { success: true, url };
-                            } catch (error) {
-                                // Only log error if it's not a generic relay rejection
-                                const errorMessage = error?.message || String(error);
-                                if (!errorMessage.includes('relay experienced an error')) {
-                                    console.error(`Error publishing to ${url}:`, error);
-                                }
-                                return { success: false, url, error: errorMessage };
-                            } finally {
-                                // Always close the relay connection, even if there was an error
-                                if (relay) {
-                                    try {
-                                        relay.close();
-                                    } catch (closeError) {
-                                        // Ignore errors when closing
-                                    }
-                                }
-                            }
-                        });
-                        
-                        const results = await Promise.allSettled(publishPromises);
-                        const successful = [];
-                        const failed = [];
-                        
-                        results.forEach((result, index) => {
-                            if (result.status === 'fulfilled') {
-                                if (result.value.success) {
-                                    successful.push(result.value.url);
-                                } else {
-                                    failed.push({ url: result.value.url, error: result.value.error });
-                                }
-                            } else {
-                                failed.push({ url: relayUrls[index], error: result.reason?.message || 'Unknown error' });
-                            }
-                        });
+                        const publishPromises = relayUrls.map(url => publishToRelayWithRetries(url, signedEvent));
+                        const results = await Promise.all(publishPromises);
+                        const successful = results.filter(r => r.success);
+                        const failed = results.filter(r => !r.success).map(r => ({ url: r.url, error: r.error }));
                         
                         if (successful.length > 0) {
                             let statusMessage = `Profile linked! Username ${username} published to ${successful.length} relay(s)`;
@@ -5386,9 +5670,26 @@
                             if (usernameIndicator) {
                                 usernameIndicator.style.display = 'block';
                             }
+                            
+                            // Update close button visibility now that profile is linked
+                            const closeBtn = document.getElementById('keys-modal-close-btn');
+                            if (closeBtn) {
+                                closeBtn.style.display = 'block';
+                            }
+                            
+                            // Hide "Update Trustroots Profile" button now that profile is linked
+                            const updateTrustrootsGroup = document.getElementById('update-trustroots-profile-group');
+                            if (updateTrustrootsGroup) {
+                                updateTrustrootsGroup.style.display = 'none';
+                            }
                         } else {
-                            const errorDetails = failed.map(f => `${new URL(f.url).hostname}`).join(', ');
-                            showStatus(`Profile validated but failed to publish to relays: ${errorDetails}`, 'error');
+                            const errorDetails = failed.map(f => {
+                                const hostname = new URL(f.url).hostname;
+                                const errorMsg = f.error ? ` (${formatRelayError(f.error)})` : '';
+                                return `${hostname}${errorMsg}`;
+                            }).join(', ');
+                            const hint = getRelayPublishFailureHint(failed);
+                            showStatus(`Profile validated but failed to publish to relays: ${errorDetails}.${hint}`, 'error', { eventPayload: signedEvent });
                         }
                     } else {
                         showStatus(`Username ${username} is linked to a different npub. This profile does not belong to you.`, 'error');
@@ -5468,11 +5769,32 @@
             // Initialize relay list
             initializeRelayList();
             
+            // Keys icon button click handler
+            const keysBtn = document.getElementById('keys-icon-btn');
+            if (keysBtn) {
+                keysBtn.addEventListener('click', () => {
+                    openKeysModal();
+                });
+            }
+            
             // Settings icon button click handler
             const settingsBtn = document.getElementById('settings-icon-btn');
             if (settingsBtn) {
                 settingsBtn.addEventListener('click', () => {
                     openSettingsModal();
+                });
+            }
+            
+            // Close keys modal when clicking outside (only if key is set and profile is linked)
+            const keysModal = document.getElementById('keys-modal');
+            if (keysModal) {
+                keysModal.addEventListener('click', (e) => {
+                    if (e.target.id === 'keys-modal') {
+                        const hasKey = !!(currentPublicKey || currentPrivateKey || usingNip07);
+                        if (hasKey && isProfileLinked) {
+                            closeKeysModal();
+                        }
+                    }
                 });
             }
             
@@ -5516,16 +5838,8 @@
                 });
             }
             
-            // Add Enter key handler for note textarea
-            const noteContentInModal = document.getElementById('note-content-in-modal');
-            if (noteContentInModal) {
-                noteContentInModal.addEventListener('keydown', (e) => {
-                    if (e.key === 'Enter' && !e.shiftKey) {
-                        e.preventDefault();
-                        publishNoteFromModal();
-                    }
-                });
-            }
+            // Note: Enter key handler for note textarea is set up in showNotesForPlusCode()
+            // with proper deduplication via enterHandlerSetup flag
             
             // Small delay to ensure DOM is ready, then initialize map
             setTimeout(() => {
@@ -5574,10 +5888,13 @@
         window.deleteNsec = deleteNsec;
         window.saveRelays = saveRelays;
         window.linkTrustrootsProfile = linkTrustrootsProfile;
+        window.updateTrustrootsProfile = updateTrustrootsProfile;
         window.publishNoteFromModal = publishNoteFromModal;
         window.closeViewNoteModal = closeViewNoteModal;
         window.closePlusCodeNotesModal = closePlusCodeNotesModal;
         window.closeSettingsModal = closeSettingsModal;
+        window.openKeysModal = openKeysModal;
+        window.closeKeysModal = closeKeysModal;
         window.onboardingGenerate = onboardingGenerate;
         window.onboardingImport = onboardingImport;
         window.onboardingConnectExtension = onboardingConnectExtension;

--- a/nr-web/package.json
+++ b/nr-web/package.json
@@ -15,8 +15,8 @@
     "test:local:watch": "vitest",
     "test:local:ui": "vitest --ui",
     "test:local:coverage": "vitest run --coverage",
-    "test:local:e2e": "playwright test",
-    "test:local:e2e:ui": "playwright test --ui",
+    "test:local:e2e": "npx playwright test",
+    "test:local:e2e:ui": "npx playwright test --ui",
     "test:local:all": "pnpm test:local && pnpm test:local:e2e"
   },
   "devDependencies": {

--- a/nr-web/tests/e2e/README.md
+++ b/nr-web/tests/e2e/README.md
@@ -1,0 +1,55 @@
+# E2E Tests - Relay Publishing
+
+## Setup
+
+To run the relay publishing tests, you need to set up a test account:
+
+1. **Copy the example.env file:**
+   ```bash
+   cp example.env .env
+   ```
+
+2. **Fill in the test account credentials in `.env`:**
+   ```bash
+   TEST_NSEC=nsec1your_test_account_nsec_here
+   TEST_TRUSTROOTS_USERNAME=your-test-username
+   ```
+
+3. **Create a test account:**
+   - Generate or use an existing Nostr key
+   - Link it to a Trustroots username with NIP-5 validation
+   - Make sure the username is verified on Trustroots
+
+4. **Run the tests:**
+   ```bash
+   # In Docker (recommended)
+   make test-e2e
+   
+   # Or run just the relay publishing tests
+   docker-compose run --rm tests pnpm test:local:e2e tests/e2e/relay-publishing.spec.js
+   ```
+
+## Test Account Requirements
+
+- The test account should have a valid nsec key
+- The Trustroots username should be linked to the pubkey (NIP-5 validated)
+- The account should be able to publish to the default relays
+
+## What the Tests Do
+
+1. **publish note to actual relay**: 
+   - Imports the test nsec key
+   - Sets the Trustroots username
+   - Publishes a test note to the relay
+   - Verifies the note appears on the relay
+
+2. **verify test account setup**:
+   - Verifies the test account credentials are valid
+   - Checks that the key can be imported
+   - Verifies Trustroots username linking
+
+## Notes
+
+- Tests are skipped automatically if `.env` is not configured
+- The tests publish real events to real relays - use a test account only!
+- Events published by tests will have unique timestamps to avoid conflicts

--- a/nr-web/tests/e2e/onboarding.spec.js
+++ b/nr-web/tests/e2e/onboarding.spec.js
@@ -10,12 +10,12 @@ test.describe('Onboarding Flow', () => {
     await page.reload();
   });
 
-  test('onboarding modal appears when no key exists', async ({ page }) => {
+  test('keys modal appears when no key exists', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
     
-    const onboardingModal = page.locator('#onboarding-modal');
-    await expect(onboardingModal).toBeVisible();
+    const keysModal = page.locator('#keys-modal');
+    await expect(keysModal).toBeVisible();
   });
 
   test('can generate new key from onboarding', async ({ page }) => {
@@ -27,9 +27,9 @@ test.describe('Onboarding Flow', () => {
     await expect(generateBtn).toBeVisible();
     await generateBtn.click();
     
-    // Wait for modal to close (onboarding should complete)
-    const onboardingModal = page.locator('#onboarding-modal');
-    await expect(onboardingModal).not.toBeVisible({ timeout: 5000 });
+    // Wait for welcome section to disappear (key was generated)
+    const welcomeSection = page.locator('#keys-welcome-section');
+    await expect(welcomeSection).not.toBeVisible({ timeout: 5000 });
     
     // Verify key was created (check localStorage)
     const hasKey = await page.evaluate(() => {
@@ -46,12 +46,12 @@ test.describe('Onboarding Flow', () => {
     await expect(importBtn).toBeVisible();
   });
 
-  test('onboarding has nsec input field', async ({ page }) => {
+  test('onboarding has import input field', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
     
-    const nsecInput = page.locator('#onboarding-nsec');
-    await expect(nsecInput).toBeVisible();
+    const importInput = page.locator('#onboarding-import');
+    await expect(importInput).toBeVisible();
   });
 
   test('onboarding shows NIP-07 option when available', async ({ page }) => {
@@ -70,22 +70,22 @@ test.describe('Onboarding Flow', () => {
     await page.waitForLoadState('networkidle');
     
     // NIP-07 section might be visible or hidden depending on detection
-    const nip07Section = page.locator('#onboarding-nip07-section');
+    const nip07Section = page.locator('#keys-nip07-section');
     // Just verify it exists, visibility depends on extension detection timing
     await expect(nip07Section).toBeAttached();
   });
 
-  test('onboarding modal cannot be closed with ESC', async ({ page }) => {
+  test('keys modal cannot be closed with ESC when no key exists', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
     
-    const onboardingModal = page.locator('#onboarding-modal');
-    await expect(onboardingModal).toBeVisible();
+    const keysModal = page.locator('#keys-modal');
+    await expect(keysModal).toBeVisible();
     
     // Try to close with ESC
     await page.keyboard.press('Escape');
     
-    // Modal should still be visible (onboarding must be completed)
-    await expect(onboardingModal).toBeVisible();
+    // Modal should still be visible (user must set up keys first)
+    await expect(keysModal).toBeVisible();
   });
 });

--- a/nr-web/tests/e2e/relay-publishing.spec.js
+++ b/nr-web/tests/e2e/relay-publishing.spec.js
@@ -1,0 +1,363 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Load .env file if it exists
+function loadEnv() {
+  const envPath = resolve(__dirname, '..', '..', '.env');
+  try {
+    const envContent = readFileSync(envPath, 'utf-8');
+    const env = {};
+    envContent.split('\n').forEach((line) => {
+      const trimmed = line.trim();
+      if (trimmed && !trimmed.startsWith('#')) {
+        const [key, ...valueParts] = trimmed.split('=');
+        if (key && valueParts.length > 0) {
+          env[key.trim()] = valueParts.join('=').trim();
+        }
+      }
+    });
+    return env;
+  } catch (error) {
+    // .env file doesn't exist, return empty object
+    return {};
+  }
+}
+
+const env = loadEnv();
+const TEST_NSEC = env.TEST_NSEC || process.env.TEST_NSEC;
+const TEST_TRUSTROOTS_USERNAME = env.TEST_TRUSTROOTS_USERNAME || process.env.TEST_TRUSTROOTS_USERNAME;
+
+// Debug: Log what we found (only in test environment)
+if (process.env.NODE_ENV !== 'production') {
+  console.log('[Relay Publishing Tests] TEST_NSEC:', TEST_NSEC ? 'SET' : 'NOT SET');
+  console.log('[Relay Publishing Tests] TEST_TRUSTROOTS_USERNAME:', TEST_TRUSTROOTS_USERNAME ? 'SET' : 'NOT SET');
+}
+
+// Skip tests if credentials are not provided
+const shouldSkip = !TEST_NSEC || !TEST_TRUSTROOTS_USERNAME;
+
+test.describe('Relay Publishing', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+  });
+
+  // TODO: This test is skipped because publishNoteFromModal requires internal variables
+  // (selectedPlusCode, currentPrivateKeyBytes) that aren't accessible from tests.
+  // To properly test this, you'd need to click on the map to set selectedPlusCode.
+  // The key import and profile linking are now tested in 'verify test account setup'.
+  test.skip('publish note to actual relay', async ({ page }) => {
+    // Clear any existing keys first
+    await page.evaluate(() => {
+      localStorage.removeItem('nostr_private_key');
+      localStorage.removeItem('using_nip07');
+      window.currentPublicKey = null;
+      window.currentPrivateKeyBytes = null;
+    });
+
+    // Open keys modal first
+    await page.evaluate(() => {
+      if (window.openKeysModal) {
+        window.openKeysModal();
+      }
+    });
+    
+    // Wait for modal to be visible and show the import section
+    await page.waitForSelector('#keys-modal', { state: 'visible' });
+    
+    // Show the import section in the keys modal
+    await page.evaluate(() => {
+      const importSection = document.getElementById('keys-import-section');
+      if (importSection) {
+        importSection.style.display = 'block';
+      }
+    });
+    
+    await page.waitForSelector('#onboarding-import', { state: 'visible' });
+    await page.waitForTimeout(300);
+
+    // Import the test nsec key using the onboarding import
+    await page.evaluate(async (nsec) => {
+      const input = document.getElementById('onboarding-import');
+      if (input && window.onboardingImport) {
+        input.value = nsec;
+        await window.onboardingImport();
+      }
+    }, TEST_NSEC);
+    
+    // Wait for key import to complete and UI to update
+    await page.waitForTimeout(1000);
+
+    // Verify key was imported - check localStorage and npub-display
+    const hasKey = await page.evaluate(() => {
+      return !!localStorage.getItem('nostr_private_key');
+    });
+    expect(hasKey).toBe(true);
+    
+    // Get public key from npub-display (populated after successful import)
+    const npubValue = await page.evaluate(() => {
+      const npubDisplay = document.getElementById('npub-display');
+      return npubDisplay ? npubDisplay.value : null;
+    });
+    expect(npubValue).toBeTruthy();
+    expect(npubValue).toMatch(/^npub1/);
+
+    // Set trustroots username
+    await page.evaluate((username) => {
+      const usernameInput = document.getElementById('trustroots-username');
+      if (usernameInput) {
+        usernameInput.value = username;
+        if (window.linkTrustrootsProfile) {
+          window.linkTrustrootsProfile();
+        }
+      }
+    }, TEST_TRUSTROOTS_USERNAME);
+
+    // Wait for profile linking (async operation)
+    await page.waitForTimeout(3000);
+
+    // Close the keys modal if it's still open
+    await page.evaluate(() => {
+      const keysModal = document.getElementById('keys-modal');
+      if (keysModal && keysModal.classList.contains('active')) {
+        keysModal.classList.remove('active');
+        keysModal.style.display = 'none';
+      }
+    });
+    await page.waitForTimeout(300);
+
+    // Create a unique test note content with timestamp
+    const testNoteContent = `Test note from automated test - ${Date.now()}`;
+    const testPlusCode = '3G000000+'; // Test location for automated tests
+
+    // Set the selected plus code and open the notes modal directly
+    // Since showNotesForPlusCode is not exposed on window, we'll set up the modal manually
+    await page.evaluate((plusCode) => {
+      // Set the selected plus code in global state
+      // These are defined in the script scope, not window, so we need to find another way
+      const modal = document.getElementById('pluscode-notes-modal');
+      const titleEl = document.getElementById('pluscode-notes-title');
+      const notesList = document.getElementById('pluscode-notes-list');
+      
+      if (titleEl) {
+        titleEl.textContent = `Notes for ${plusCode}`;
+        titleEl.dataset.pluscode = plusCode;
+      }
+      
+      // Clear any existing notes
+      if (notesList) {
+        notesList.innerHTML = '';
+      }
+      
+      // Show the modal
+      if (modal) {
+        modal.classList.add('active');
+      }
+    }, testPlusCode);
+
+    // Wait for modal to be visible and input to be available
+    await page.waitForSelector('#pluscode-notes-modal.active', { state: 'visible' });
+    await page.waitForSelector('#note-content-in-modal', { state: 'visible' });
+    await page.waitForTimeout(500);
+
+    // Set the note content in the modal and the selected plus code for publishing
+    await page.fill('#note-content-in-modal', testNoteContent);
+    
+    // We also need to set selectedPlusCode which the publish function will use
+    // Check if we can do this through the modal title's dataset
+    await page.evaluate((plusCode) => {
+      // Try to set it through the title element which publishNoteFromModal reads
+      const titleEl = document.getElementById('pluscode-notes-title');
+      if (titleEl) {
+        titleEl.dataset.pluscode = plusCode;
+      }
+    }, testPlusCode);
+    
+    await page.waitForTimeout(200);
+
+    // Publish the note - wait for the promise to resolve
+    await page.evaluate(async () => {
+      if (window.publishNoteFromModal) {
+        await window.publishNoteFromModal();
+      }
+    });
+
+    // Wait for publishing to complete and status messages
+    await page.waitForTimeout(5000);
+
+    // Query the relay to verify the event was published
+    // Use the browser context to query the relay using nostr-tools
+    const eventFound = await page.evaluate(
+      async ({ npubValue, testNoteContent }) => {
+        // Import nostr-tools to decode npub and query relay
+        const nostrTools = await import('https://cdn.jsdelivr.net/npm/nostr-tools@2.10.3/+esm');
+        const { Relay, nip19 } = nostrTools;
+        const relayUrl = 'wss://relay.trustroots.org';
+        
+        // Decode npub to get hex public key
+        let publicKey;
+        try {
+          const decoded = nip19.decode(npubValue);
+          publicKey = decoded.data;
+        } catch (e) {
+          console.error('Failed to decode npub:', e);
+          return false;
+        }
+        
+        return new Promise((resolve) => {
+          let found = false;
+          let timeoutId;
+          
+          Relay.connect(relayUrl)
+            .then((relay) => {
+              const sub = relay.subscribe(
+                [
+                  {
+                    kinds: [30397], // MAP_NOTE_KIND
+                    authors: [publicKey],
+                    limit: 10,
+                  },
+                ],
+                {
+                  onevent: (event) => {
+                    // Check if this is our test event
+                    if (event.content === testNoteContent) {
+                      found = true;
+                      clearTimeout(timeoutId);
+                      sub.close();
+                      relay.close();
+                      resolve(true);
+                    }
+                  },
+                  oneose: () => {
+                    clearTimeout(timeoutId);
+                    sub.close();
+                    relay.close();
+                    resolve(found);
+                  },
+                }
+              );
+
+              // Timeout after 10 seconds
+              timeoutId = setTimeout(() => {
+                sub.close();
+                relay.close();
+                resolve(found);
+              }, 10000);
+            })
+            .catch(() => {
+              // Relay connection failed
+              resolve(false);
+            });
+        });
+      },
+      { npubValue, testNoteContent }
+    );
+
+    // Check status messages to see if publishing succeeded
+    const statusMessages = await page.evaluate(() => {
+      const statusContainer = document.getElementById('status-container');
+      return statusContainer ? statusContainer.textContent : '';
+    });
+
+    // If event was found on relay, great!
+    // If not, check if there was a publishing error
+    if (!eventFound) {
+      // Publishing might have succeeded but event not yet visible
+      // or relay might be slow. Check status for errors.
+      if (statusMessages.includes('error') || statusMessages.includes('Error')) {
+        throw new Error(`Publishing failed: ${statusMessages}`);
+      }
+      // Otherwise, event might just not be visible yet (relay delay)
+      console.warn('Event not found on relay yet (might be delayed)');
+    } else {
+      expect(eventFound).toBe(true);
+    }
+  });
+
+  (shouldSkip ? test.skip : test)('verify test account setup', async ({ page }) => {
+    // This test verifies that the test account credentials are valid
+    // Clear any existing keys first
+    await page.evaluate(() => {
+      localStorage.removeItem('nostr_private_key');
+      localStorage.removeItem('using_nip07');
+      window.currentPublicKey = null;
+      window.currentPrivateKeyBytes = null;
+    });
+
+    // Open keys modal first
+    await page.evaluate(() => {
+      if (window.openKeysModal) {
+        window.openKeysModal();
+      }
+    });
+    
+    // Wait for modal to be visible and show the import section
+    await page.waitForSelector('#keys-modal', { state: 'visible' });
+    
+    // Show the import section in the keys modal
+    await page.evaluate(() => {
+      const importSection = document.getElementById('keys-import-section');
+      if (importSection) {
+        importSection.style.display = 'block';
+      }
+    });
+    
+    await page.waitForSelector('#onboarding-import', { state: 'visible' });
+    await page.waitForTimeout(300);
+
+    // Import the test nsec key using the onboarding import
+    await page.evaluate(async (nsec) => {
+      const input = document.getElementById('onboarding-import');
+      if (input && window.onboardingImport) {
+        input.value = nsec;
+        await window.onboardingImport();
+      }
+    }, TEST_NSEC);
+    
+    // Wait for key import to complete and UI to update
+    await page.waitForTimeout(1000);
+
+    // Verify key was imported - check localStorage and npub-display
+    const hasKey = await page.evaluate(() => {
+      return !!localStorage.getItem('nostr_private_key');
+    });
+    expect(hasKey).toBe(true);
+    
+    // Get public key from npub-display (populated after successful import)
+    const npubValue = await page.evaluate(() => {
+      const npubDisplay = document.getElementById('npub-display');
+      return npubDisplay ? npubDisplay.value : null;
+    });
+    expect(npubValue).toBeTruthy();
+    expect(npubValue).toMatch(/^npub1/);
+
+    // Verify trustroots username is linked
+    await page.evaluate((username) => {
+      const usernameInput = document.getElementById('trustroots-username');
+      if (usernameInput) {
+        usernameInput.value = username;
+        if (window.linkTrustrootsProfile) {
+          window.linkTrustrootsProfile();
+        }
+      }
+    }, TEST_TRUSTROOTS_USERNAME);
+
+    await page.waitForTimeout(3000);
+
+    // Check if profile is linked
+    const isProfileLinked = await page.evaluate(() => {
+      return window.isProfileLinked || false;
+    });
+
+    // Note: Profile linking might fail if NIP-5 is not set up
+    // This is informational, not a hard failure
+    if (!isProfileLinked) {
+      console.warn('Trustroots profile is not linked. Make sure NIP-5 is configured.');
+    }
+  });
+});

--- a/nr-web/tests/integration/forms.test.js
+++ b/nr-web/tests/integration/forms.test.js
@@ -25,29 +25,35 @@ describe('Form Interactions', () => {
       expect(button).toBeTruthy();
     });
 
-    it('onboarding nsec input exists', () => {
-      const input = document.getElementById('onboarding-nsec');
-      expect(input).toBeTruthy();
+    it('onboarding import textarea exists', () => {
+      const textarea = document.getElementById('onboarding-import');
+      expect(textarea).toBeTruthy();
+      expect(textarea.tagName).toBe('TEXTAREA');
     });
   });
 
   describe('Relay Settings Form', () => {
-    it('relay URLs textarea exists', () => {
-      const textarea = document.getElementById('relay-urls');
-      expect(textarea).toBeTruthy();
-      expect(textarea.tagName).toBe('TEXTAREA');
+    it('relays list container exists', () => {
+      const container = document.getElementById('relays-list');
+      expect(container).toBeTruthy();
     });
 
-    it('can set and get relay URLs', () => {
-      const textarea = document.getElementById('relay-urls');
-      const testUrls = 'wss://relay1.com\nwss://relay2.com';
-      textarea.value = testUrls;
-      expect(textarea.value).toBe(testUrls);
+    it('new relay URL input exists', () => {
+      const input = document.getElementById('new-relay-url');
+      expect(input).toBeTruthy();
+      expect(input.tagName).toBe('INPUT');
     });
 
-    it('has save button', () => {
-      const textarea = document.getElementById('relay-urls');
-      const button = textarea?.parentElement?.querySelector('button[onclick*="saveRelays"]');
+    it('can set and get new relay URL input', () => {
+      const input = document.getElementById('new-relay-url');
+      const testUrl = 'wss://relay1.com';
+      input.value = testUrl;
+      expect(input.value).toBe(testUrl);
+    });
+
+    it('has add relay button', () => {
+      const input = document.getElementById('new-relay-url');
+      const button = input?.parentElement?.querySelector('button[onclick*="addRelay"]');
       expect(button).toBeTruthy();
     });
   });
@@ -66,9 +72,10 @@ describe('Form Interactions', () => {
       expect(input.value).toBe(testUsername);
     });
 
-    it('has link profile button', () => {
-      const button = document.getElementById('link-profile-btn');
-      expect(button).toBeTruthy();
+    it('username input triggers link on Enter', () => {
+      const input = document.getElementById('trustroots-username');
+      // Link profile button was removed, but Enter key on username input triggers linkTrustrootsProfile
+      expect(input.getAttribute('onkeydown')).toContain('linkTrustrootsProfile');
     });
 
     it('has username indicator element', () => {

--- a/nr-web/tests/integration/modals.test.js
+++ b/nr-web/tests/integration/modals.test.js
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 describe('Modal Behavior', () => {
   beforeEach(() => {
     // Reset modal states
-    const modals = ['settings-modal', 'onboarding-modal', 'view-note-modal', 'pluscode-notes-modal', 'add-note-modal'];
+    const modals = ['settings-modal', 'keys-modal', 'view-note-modal', 'pluscode-notes-modal', 'circles-modal'];
     modals.forEach(id => {
       const modal = document.getElementById(id);
       if (modal) {
@@ -31,14 +31,14 @@ describe('Modal Behavior', () => {
     });
   });
 
-  describe('Onboarding Modal', () => {
-    it('onboarding modal element exists', () => {
-      const modal = document.getElementById('onboarding-modal');
+  describe('Keys Modal', () => {
+    it('keys modal element exists', () => {
+      const modal = document.getElementById('keys-modal');
       expect(modal).toBeTruthy();
     });
 
     it('has key generation options', () => {
-      const modal = document.getElementById('onboarding-modal');
+      const modal = document.getElementById('keys-modal');
       const generateBtn = modal?.querySelector('button[onclick*="onboardingGenerate"]');
       const importBtn = modal?.querySelector('button[onclick*="onboardingImport"]');
       
@@ -47,7 +47,7 @@ describe('Modal Behavior', () => {
     });
 
     it('has NIP-07 section', () => {
-      const nip07Section = document.getElementById('onboarding-nip07-section');
+      const nip07Section = document.getElementById('keys-nip07-section');
       expect(nip07Section).toBeTruthy();
     });
   });
@@ -74,7 +74,7 @@ describe('Modal Behavior', () => {
 
   describe('Modal structure', () => {
     it('all modals have modal-content wrapper', () => {
-      const modals = ['settings-modal', 'onboarding-modal', 'view-note-modal'];
+      const modals = ['settings-modal', 'keys-modal', 'view-note-modal'];
       modals.forEach(id => {
         const modal = document.getElementById(id);
         const content = modal?.querySelector('.modal-content');

--- a/nr-web/tests/unit/key-management.test.js
+++ b/nr-web/tests/unit/key-management.test.js
@@ -44,11 +44,11 @@ describe('Key Management', () => {
     });
 
     it('has onboarding elements', () => {
-      const onboardingNsec = document.getElementById('onboarding-nsec');
-      const onboardingModal = document.getElementById('onboarding-modal');
+      const onboardingImport = document.getElementById('onboarding-import');
+      const keysModal = document.getElementById('keys-modal');
       
-      expect(onboardingNsec).toBeTruthy();
-      expect(onboardingModal).toBeTruthy();
+      expect(onboardingImport).toBeTruthy();
+      expect(keysModal).toBeTruthy();
     });
   });
 

--- a/nr-web/tests/unit/relay-management.test.js
+++ b/nr-web/tests/unit/relay-management.test.js
@@ -27,9 +27,12 @@ describe('Relay Management', () => {
 
   describe('Relay settings UI', () => {
     it('has relay settings form elements', () => {
-      const relayUrlsTextarea = document.getElementById('relay-urls');
-      expect(relayUrlsTextarea).toBeTruthy();
-      expect(relayUrlsTextarea.tagName).toBe('TEXTAREA');
+      const relaysList = document.getElementById('relays-list');
+      expect(relaysList).toBeTruthy();
+      
+      const newRelayInput = document.getElementById('new-relay-url');
+      expect(newRelayInput).toBeTruthy();
+      expect(newRelayInput.tagName).toBe('INPUT');
     });
   });
 


### PR DESCRIPTION
- strfry server
- plugin that should validate trustroots.org nip5 of npub before allowing user to post
- later: only allow reading with valid nip5
- already running at 5str.nomadwiki.org

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: introduces a new `strfry` write-policy gate (allowlist persisted to disk) and refactors client key/onboarding + relay publish flows with retries and stricter modal constraints, which can affect event acceptance/publishing behavior.
> 
> **Overview**
> Adds a new `5strfry` containerized Strfry relay with a custom write-policy plugin that **always accepts kind 0** and builds a persisted pubkey allowlist from `nip05` values ending in `@trustroots.org`, rejecting all other event kinds for non-allowlisted pubkeys.
> 
> Updates `nr-web` key UX by replacing the onboarding modal with a dedicated **Keys** modal (new floating button), supporting *nsec or BIP39 mnemonic import*, adding an “Update Trustroots Profile” helper, and gating modal dismissal on having keys + a linked Trustroots profile.
> 
> Hardens relay publishing in `nr-web` with pre/post-sign validation, per-relay publish **retries**, improved error formatting/hints, and richer status messages (optional event JSON copy/view). Also adjusts local relay URL input to auto-prepend `ws://` when users enter `host:port`.
> 
> Improves test/dev tooling: simplifies `nr-web` Playwright Docker setup (non-workspace install), adds `.env` template + E2E relay-publishing coverage updates, and introduces a `nr-push/strfry` backup script to export the relay DB.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3438e4290395d4a73574733da3124e281dc2db89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->