### PR TITLE
feat: connectWithRetry for amqp; + amqp package

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,11 @@
+{
+  "nodeModulesDir": "auto",
+  "workspace": [
+    "./nr-common",
+    "./nr-server",
+    "./nr-relay-to-rabbit",
+    "./nr-notification-daemon",
+    "./nr-monitor",
+    "./packages/amqp"
+  ]
+}

--- a/nr-monitor/deno.json
+++ b/nr-monitor/deno.json
@@ -5,7 +5,6 @@
     "check": "deno run --allow-net --allow-env main.ts --check-once"
   },
   "imports": {
-    "@trustroots/nr-common": "../nr-common/mod.ts",
     "zod": "npm:zod@^3.25.76",
     "nostr-tools/pure": "npm:nostr-tools@2.10.4/pure",
     "nostr-tools/relay": "npm:nostr-tools@2.10.4/relay",

--- a/nr-notification-daemon/deno.json
+++ b/nr-notification-daemon/deno.json
@@ -5,6 +5,7 @@
   },
   "imports": {
     "@trustroots/nr-common": "../nr-common/mod.ts",
+    "@trustroots/amqp": "../packages/amqp/mod.ts",
     "@nashaddams/amqp": "jsr:@nashaddams/amqp@1.1.0",
     "zod": "npm:zod@^3.25.76",
     "nostr-tools": "npm:nostr-tools@2.10.4",

--- a/nr-notification-daemon/deno.json
+++ b/nr-notification-daemon/deno.json
@@ -4,8 +4,6 @@
     "dev": "deno run --allow-net --allow-env --watch main.ts"
   },
   "imports": {
-    "@trustroots/nr-common": "../nr-common/mod.ts",
-    "@trustroots/amqp": "../packages/amqp/mod.ts",
     "@nashaddams/amqp": "jsr:@nashaddams/amqp@1.1.0",
     "zod": "npm:zod@^3.25.76",
     "nostr-tools": "npm:nostr-tools@2.10.4",

--- a/nr-notification-daemon/deno.lock
+++ b/nr-notification-daemon/deno.lock
@@ -2,6 +2,7 @@
   "version": "5",
   "specifiers": {
     "jsr:@nashaddams/amqp@1.1.0": "1.1.0",
+    "jsr:@nashaddams/amqp@^1.1.0": "1.1.0",
     "jsr:@std/bytes@^1.0.2": "1.0.6",
     "jsr:@std/io@0.225.0": "0.225.0",
     "npm:@noble/hashes@1.7.1": "1.7.1",

--- a/nr-relay-to-rabbit/deno.json
+++ b/nr-relay-to-rabbit/deno.json
@@ -4,8 +4,6 @@
     "dev": "deno run --allow-net --allow-env --watch main.ts"
   },
   "imports": {
-    "@trustroots/nr-common": "../nr-common/mod.ts",
-    "@trustroots/amqp": "../packages/amqp/mod.ts",
     "@nashaddams/amqp": "jsr:@nashaddams/amqp@1.1.0",
     "zod": "npm:zod@^3.25.76"
   }

--- a/nr-relay-to-rabbit/deno.json
+++ b/nr-relay-to-rabbit/deno.json
@@ -5,6 +5,7 @@
   },
   "imports": {
     "@trustroots/nr-common": "../nr-common/mod.ts",
+    "@trustroots/amqp": "../packages/amqp/mod.ts",
     "@nashaddams/amqp": "jsr:@nashaddams/amqp@1.1.0",
     "zod": "npm:zod@^3.25.76"
   }

--- a/nr-relay-to-rabbit/main.ts
+++ b/nr-relay-to-rabbit/main.ts
@@ -1,5 +1,5 @@
-import * as amqp from "@nashaddams/amqp";
 import { AMQP_EXCHANGE_NAME, AMQP_EXCHANGE_TYPE } from "@trustroots/nr-common";
+import { connectWithRetry } from "@trustroots/amqp";
 import { parseJsonLine } from "./src/parseLines.ts";
 import { acceptEvent, rejectEvent } from "./src/strfryResponses.ts";
 import { whitelistKinds } from "./src/whitelistKinds.ts";
@@ -11,19 +11,7 @@ if (typeof amqpUrl === "undefined" || amqpUrl.length === 0) {
   Deno.exit(1);
 }
 
-const url = URL.parse(amqpUrl);
-
-if (url === null) {
-  console.error("#Nmo5gQ Failed to parse AMQP url");
-  Deno.exit(1);
-}
-
-const connection = await amqp.connect({
-  hostname: url.hostname,
-  port: parseInt(url.port),
-  username: url.username,
-  password: url.password,
-});
+const connection = await connectWithRetry(amqpUrl);
 
 const channel = await connection.openChannel();
 

--- a/nr-relay-to-rabbit/src/parseLines.ts
+++ b/nr-relay-to-rabbit/src/parseLines.ts
@@ -1,19 +1,11 @@
-import { z } from "zod";
-import { eventSchema } from "@trustroots/nr-common";
+import { rabbitMessageSchema, type RabbitMessage } from "@trustroots/amqp";
 
-export const stryfrLineSchema = z.object({
-  type: z.literal("new"),
-  event: eventSchema,
-  receivedAt: z.number().int(),
-  sourceType: z.string(),
-  sourceInfo: z.string(),
-});
-export type StrfryLine = z.infer<typeof stryfrLineSchema>;
+export type StrfryLine = RabbitMessage;
 
 export function parseJsonLine(input: string) {
   try {
     const parsedInput = JSON.parse(input);
-    const strfryLine = stryfrLineSchema.parse(parsedInput);
+    const strfryLine = rabbitMessageSchema.parse(parsedInput);
     return strfryLine;
   } catch (error) {
     const errorMessage =

--- a/nr-server/deno.jsonc
+++ b/nr-server/deno.jsonc
@@ -6,5 +6,6 @@
   "imports": {
     "zod": "npm:zod@^3.23.8",
     "@trustroots/nr-common": "../nr-common/mod.ts",
+    "@trustroots/amqp": "../packages/amqp/mod.ts"
   },
 }

--- a/nr-server/deno.jsonc
+++ b/nr-server/deno.jsonc
@@ -4,8 +4,6 @@
     "cache": "deno cache --lock deno.lock deps.ts",
   },
   "imports": {
-    "zod": "npm:zod@^3.23.8",
-    "@trustroots/nr-common": "../nr-common/mod.ts",
-    "@trustroots/amqp": "../packages/amqp/mod.ts"
+    "zod": "npm:zod@^3.23.8"
   },
 }

--- a/nr-server/deps.ts
+++ b/nr-server/deps.ts
@@ -9,7 +9,6 @@ export const newQueue = newQueueImport;
 export * as logPackage from "jsr:@std/log@0.224.5";
 export * as async from "jsr:@std/async@1.0.3";
 export * as expect from "jsr:@std/expect@1.0.13";
-export * as amqp from "jsr:@nashaddams/amqp@1.1.0";
 export * as nanoid from "jsr:@sitnik/nanoid@5.1.5";
 import { z } from "zod";
 export { z };

--- a/packages/amqp/deno.jsonc
+++ b/packages/amqp/deno.jsonc
@@ -1,0 +1,11 @@
+{
+  "name": "@trustroots/amqp",
+  "version": "0.0.1",
+  "exports": "./mod.ts",
+  "imports": {
+    "@nashaddams/amqp": "jsr:@nashaddams/amqp@^1.1.0",
+    "@trustroots/nr-common": "../../nr-common/mod.ts",
+    "zod": "npm:zod@^3.25.76"
+  },
+  "license": "AGPL-3.0-or-later"
+}

--- a/packages/amqp/deno.jsonc
+++ b/packages/amqp/deno.jsonc
@@ -2,10 +2,5 @@
   "name": "@trustroots/amqp",
   "version": "0.0.1",
   "exports": "./mod.ts",
-  "imports": {
-    "@nashaddams/amqp": "jsr:@nashaddams/amqp@^1.1.0",
-    "@trustroots/nr-common": "../../nr-common/mod.ts",
-    "zod": "npm:zod@^3.25.76"
-  },
   "license": "AGPL-3.0-or-later"
 }

--- a/packages/amqp/message.ts
+++ b/packages/amqp/message.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "npm:zod@^3.25.76";
 import { eventSchema } from "@trustroots/nr-common";
 
 export const rabbitMessageSchema = z.object({

--- a/packages/amqp/message.ts
+++ b/packages/amqp/message.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { eventSchema } from "@trustroots/nr-common";
+
+export const rabbitMessageSchema = z.object({
+  type: z.literal("new"),
+  event: eventSchema,
+  receivedAt: z.number().int(),
+  sourceType: z.string(),
+  sourceInfo: z.string(),
+});
+
+export type RabbitMessage = z.infer<typeof rabbitMessageSchema>;

--- a/packages/amqp/mod.ts
+++ b/packages/amqp/mod.ts
@@ -1,4 +1,4 @@
-import * as amqp from "@nashaddams/amqp";
+import * as amqp from "jsr:@nashaddams/amqp@^1.1.0";
 
 export { rabbitMessageSchema, type RabbitMessage } from "./message.ts";
 

--- a/packages/amqp/mod.ts
+++ b/packages/amqp/mod.ts
@@ -1,0 +1,41 @@
+import * as amqp from "@nashaddams/amqp";
+
+export { rabbitMessageSchema, type RabbitMessage } from "./message.ts";
+
+const RETRY_DELAY_MS = 5000;
+const RETRY_JITTER_MS = 2000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getRetryDelay(): number {
+  return RETRY_DELAY_MS + Math.floor(Math.random() * RETRY_JITTER_MS);
+}
+
+export type AmqpConnection = Awaited<ReturnType<typeof amqp.connect>>;
+
+export async function connectWithRetry(url: string): Promise<AmqpConnection> {
+  const parsedUrl = URL.parse(url);
+  if (parsedUrl === null) {
+    throw new Error(`#jwBa1l Failed to parse AMQP URL: ${url}`);
+  }
+
+  try {
+    console.debug(`#Kx7Rm2 Connecting to RabbitMQ...`);
+    return await amqp.connect({
+      hostname: parsedUrl.hostname,
+      port: parseInt(parsedUrl.port),
+      username: parsedUrl.username,
+      password: parsedUrl.password,
+    });
+  } catch (error) {
+    const delayMs = getRetryDelay();
+    console.error(
+      `#Np9To4 Connection failed, retrying in ${delayMs}ms...`,
+      error,
+    );
+    await sleep(delayMs);
+    return connectWithRetry(url);
+  }
+}


### PR DESCRIPTION
This is sort of a proposal for how we could have smaller shared packages, because nr-common is in my opinion quite crowded and more modular packages can help us to figure out better abstractions down the line. It keeps things related to a domain bundled together and allows for more clear dependency scoping, no need for a build or publish for that, etc.

Can be improved upon but generally wondering if this is something we might want. I do it like this on plenty of projects.

As an example, it fixes an issue where the validations server would not be able to recover when the amqp connection fails, and it's ported to all the other apps using it.