### PR TITLE
feat(nr-app): tabbed discovery feed with signals and events

### DIFF
--- a/nr-app/app/(main)/(map)/list.tsx
+++ b/nr-app/app/(main)/(map)/list.tsx
@@ -1,127 +1,34 @@
-import { useMemo, useState } from "react";
-import { FlatList, View } from "react-native";
-import { ArrowDownUp } from "lucide-react-native";
-import { MAP_NOTE_REPOST_KIND } from "@trustroots/nr-common";
+import { useState } from "react";
+import { View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import { EmptyState } from "@/components/EmptyState";
-import NotesSingle from "@/components/NotesSingle";
-import { Button } from "@/components/ui/button";
-import { Icon } from "@/components/ui/icon";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  DiscoveryTabs,
+  DiscoveryTab,
+} from "@/components/discovery/DiscoveryTabs";
+import { FeedTab } from "@/components/discovery/FeedTab";
+import { SignalsTab } from "@/components/discovery/SignalsTab";
+import { EventsTab } from "@/components/discovery/EventsTab";
 import { Text } from "@/components/ui/text";
-import { useAppSelector } from "@/redux/hooks";
-import {
-  eventsSelectors,
-  EventWithMetadata,
-} from "@/redux/slices/events.slice";
-
-type KindFilter = "all" | "map-notes";
-type SortOrder = "newest" | "oldest";
-
-const FILTER_OPTIONS: { value: KindFilter; label: string }[] = [
-  { value: "map-notes", label: "Map Notes" },
-  { value: "all", label: "All Events" },
-];
 
 export default function ListScreen() {
-  const [kindFilter, setKindFilter] = useState<KindFilter>("map-notes");
-  const [sortOrder, setSortOrder] = useState<SortOrder>("newest");
-
-  const allEvents = useAppSelector(eventsSelectors.selectAll);
-
-  const filteredEvents = useMemo(() => {
-    const events =
-      kindFilter === "all"
-        ? allEvents
-        : allEvents.filter((e) => e.event.kind === MAP_NOTE_REPOST_KIND);
-
-    return [...events].sort((a, b) =>
-      sortOrder === "newest"
-        ? b.event.created_at - a.event.created_at
-        : a.event.created_at - b.event.created_at,
-    );
-  }, [allEvents, kindFilter, sortOrder]);
-
-  const toggleSortOrder = () => {
-    setSortOrder((prev) => (prev === "newest" ? "oldest" : "newest"));
-  };
-
-  const renderItem = ({ item }: { item: EventWithMetadata }) => (
-    <NotesSingle eventWithMetadata={item} isSelected={false} />
-  );
-
-  const ListHeader = () => (
-    <View>
-      <Text variant="h1">Notes</Text>
-      <Text variant="muted" className="mb-4">
-        {filteredEvents.length} notes
-      </Text>
-
-      <View className="flex-row items-center gap-2 mb-4">
-        <Select
-          value={{
-            value: kindFilter,
-            label:
-              FILTER_OPTIONS.find((o) => o.value === kindFilter)?.label ?? "",
-          }}
-          onValueChange={(option) => {
-            if (option) {
-              setKindFilter(option.value as KindFilter);
-            }
-          }}
-        >
-          <SelectTrigger size="sm" className="flex-1">
-            <SelectValue placeholder="Filter by type" />
-          </SelectTrigger>
-          <SelectContent>
-            {FILTER_OPTIONS.map((option) => (
-              <SelectItem
-                key={option.value}
-                value={option.value}
-                label={option.label}
-              >
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Button
-          variant="outline"
-          size="sm"
-          onPress={toggleSortOrder}
-          className="flex-row items-center gap-1"
-        >
-          <Icon as={ArrowDownUp} size={16} className="text-foreground" />
-          <Text className="text-sm text-foreground">
-            {sortOrder === "newest" ? "Newest" : "Oldest"}
-          </Text>
-        </Button>
-      </View>
-    </View>
-  );
+  const [activeTab, setActiveTab] = useState<DiscoveryTab>("feed");
+  const insets = useSafeAreaInsets();
 
   return (
-    <FlatList
-      data={filteredEvents}
-      keyExtractor={(item) => item.event.id}
-      renderItem={renderItem}
-      ListHeaderComponent={ListHeader}
-      ListEmptyComponent={
-        <EmptyState
-          title="No notes yet"
-          description="Notes will appear here once they are created"
-        />
-      }
-      contentContainerClassName="p-safe-offset-4 bg-background"
-      contentContainerStyle={{ flexGrow: 1 }}
-      ItemSeparatorComponent={() => <View className="h-4" />}
-    />
+    <View className="flex-1 bg-background" style={{ paddingTop: insets.top }}>
+      {/* Header */}
+      <View className="px-4 pt-2 pb-1">
+        <Text variant="h1">Discover</Text>
+      </View>
+
+      {/* Tabs */}
+      <DiscoveryTabs activeTab={activeTab} onTabChange={setActiveTab} />
+
+      {/* Tab content */}
+      {activeTab === "feed" && <FeedTab />}
+      {activeTab === "signals" && <SignalsTab />}
+      {activeTab === "events" && <EventsTab />}
+    </View>
   );
 }

--- a/nr-app/src/components/discovery/DiscoveryTabs.tsx
+++ b/nr-app/src/components/discovery/DiscoveryTabs.tsx
@@ -1,0 +1,42 @@
+import { Pressable, View } from "react-native";
+import { Text } from "@/components/ui/text";
+
+export type DiscoveryTab = "feed" | "signals" | "events";
+
+const TABS: { key: DiscoveryTab; label: string }[] = [
+  { key: "feed", label: "Feed" },
+  { key: "signals", label: "Signals" },
+  { key: "events", label: "Events" },
+];
+
+interface DiscoveryTabsProps {
+  activeTab: DiscoveryTab;
+  onTabChange: (tab: DiscoveryTab) => void;
+}
+
+export function DiscoveryTabs({ activeTab, onTabChange }: DiscoveryTabsProps) {
+  return (
+    <View className="flex-row border-b border-border">
+      {TABS.map((tab) => {
+        const isActive = tab.key === activeTab;
+        return (
+          <Pressable
+            key={tab.key}
+            onPress={() => onTabChange(tab.key)}
+            className={`flex-1 items-center py-3 ${
+              isActive ? "border-b-2 border-primary" : ""
+            }`}
+          >
+            <Text
+              className={`text-sm font-semibold ${
+                isActive ? "text-primary" : "text-muted-foreground"
+              }`}
+            >
+              {tab.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}

--- a/nr-app/src/components/discovery/EventCard.tsx
+++ b/nr-app/src/components/discovery/EventCard.tsx
@@ -1,0 +1,144 @@
+import { useAppSelector } from "@/redux/hooks";
+import {
+  eventsSelectors,
+  EventWithMetadata,
+} from "@/redux/slices/events.slice";
+import { selectProfileByPubkey } from "@/redux/slices/profiles.slice";
+import { getPlusCodeFromEvent } from "@/utils/event.utils";
+import {
+  getAuthorFromEvent,
+  getFirstTagValueFromEvent,
+} from "@trustroots/nr-common";
+import { BadgeCheck, CalendarDays, MapPin } from "lucide-react-native";
+import { useMemo } from "react";
+import { Image, View } from "react-native";
+import { Icon } from "@/components/ui/icon";
+import { Text } from "@/components/ui/text";
+
+function formatEventDate(timestampSeconds: number): string {
+  const date = new Date(timestampSeconds * 1000);
+  const now = new Date();
+  const isToday = date.toDateString() === now.toDateString();
+
+  const timeStr = date.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  if (isToday) {
+    return `Today at ${timeStr}`;
+  }
+
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  if (date.toDateString() === tomorrow.toDateString()) {
+    return `Tomorrow at ${timeStr}`;
+  }
+
+  const dateStr = date.toLocaleDateString([], {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+  return `${dateStr} at ${timeStr}`;
+}
+
+export default function EventCard({
+  eventWithMetadata,
+}: {
+  eventWithMetadata: EventWithMetadata;
+}) {
+  const pubkey = getAuthorFromEvent(eventWithMetadata.event);
+  const profile = useAppSelector((state) =>
+    selectProfileByPubkey(state, pubkey),
+  );
+  const selectUsername = useMemo(
+    () => eventsSelectors.selectTrustrootsUsernameFactory(pubkey),
+    [pubkey],
+  );
+  const username = useAppSelector(selectUsername);
+  const displayName = profile?.name || username;
+  const avatarLetter = (displayName || "?")[0].toUpperCase();
+
+  const plusCode = getPlusCodeFromEvent(eventWithMetadata.event);
+
+  // Get the start tag for the event date
+  const startTag = getFirstTagValueFromEvent(eventWithMetadata.event, "start");
+  const startTimestamp = startTag ? parseInt(startTag) : undefined;
+
+  // Use event title from the "title" tag, or fall back to content
+  const title = getFirstTagValueFromEvent(eventWithMetadata.event, "title");
+  const content = eventWithMetadata.event.content;
+
+  return (
+    <View className="mx-3 my-0.5 rounded-xl bg-card border border-blue-200 dark:border-blue-800 overflow-hidden">
+      {/* Blue accent bar */}
+      <View className="h-1 bg-blue-500" />
+
+      <View className="p-4">
+        {/* Title */}
+        <Text className="text-base font-bold text-foreground">
+          {title || content}
+        </Text>
+
+        {/* Start date */}
+        {startTimestamp && (
+          <View className="flex-row items-center gap-1.5 mt-2">
+            <Icon as={CalendarDays} size={14} className="text-blue-500" />
+            <Text className="text-sm text-blue-600 dark:text-blue-400 font-medium">
+              {formatEventDate(startTimestamp)}
+            </Text>
+          </View>
+        )}
+
+        {/* Location */}
+        {plusCode && (
+          <View className="flex-row items-center gap-1.5 mt-1.5">
+            <Icon as={MapPin} size={14} className="text-muted-foreground" />
+            <Text className="text-xs text-muted-foreground">{plusCode}</Text>
+          </View>
+        )}
+
+        {/* Description (only if there is both title and content) */}
+        {title && content && (
+          <Text
+            className="text-sm text-muted-foreground mt-2"
+            numberOfLines={2}
+          >
+            {content}
+          </Text>
+        )}
+
+        {/* Author */}
+        <View className="flex-row items-center gap-2 mt-3 pt-3 border-t border-border/50">
+          {profile?.picture ? (
+            <Image
+              source={{ uri: profile.picture }}
+              className="h-6 w-6 rounded-full"
+            />
+          ) : (
+            <View className="h-6 w-6 items-center justify-center rounded-full bg-blue-500/20">
+              <Text className="text-[10px] font-bold text-blue-500">
+                {avatarLetter}
+              </Text>
+            </View>
+          )}
+          {typeof username !== "undefined" ? (
+            <View className="flex-row items-center gap-0.5">
+              <Text className="text-xs font-medium text-primary">
+                {displayName}
+              </Text>
+              <Icon as={BadgeCheck} size={11} className="text-primary" />
+            </View>
+          ) : displayName ? (
+            <Text className="text-xs font-medium text-foreground">
+              {displayName}
+            </Text>
+          ) : (
+            <Text className="text-xs text-muted-foreground">Anonymous</Text>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/nr-app/src/components/discovery/EventsTab.tsx
+++ b/nr-app/src/components/discovery/EventsTab.tsx
@@ -1,0 +1,97 @@
+import { useMemo, useState } from "react";
+import { FlatList, View } from "react-native";
+import {
+  getFirstTagValueFromEvent,
+  MAP_NOTE_REPOST_KIND,
+} from "@trustroots/nr-common";
+
+import { EmptyState } from "@/components/EmptyState";
+import EventCard from "./EventCard";
+import { FilterChips, FilterChip } from "./FilterChips";
+import { useAppSelector } from "@/redux/hooks";
+import {
+  eventsSelectors,
+  EventWithMetadata,
+} from "@/redux/slices/events.slice";
+
+type EventFilter = "upcoming" | "this-week" | "past";
+
+const EVENT_CHIPS: FilterChip[] = [
+  { key: "upcoming", label: "Upcoming" },
+  { key: "this-week", label: "This week" },
+  { key: "past", label: "Past" },
+];
+
+function getStartTimestamp(event: EventWithMetadata): number | undefined {
+  const startTag = getFirstTagValueFromEvent(event.event, "start");
+  return startTag ? parseInt(startTag) : undefined;
+}
+
+function isEventNote(event: EventWithMetadata): boolean {
+  return event.event.tags.some((tag) => tag[0] === "start");
+}
+
+export function EventsTab() {
+  const [filter, setFilter] = useState<EventFilter>("upcoming");
+  const allEvents = useAppSelector(eventsSelectors.selectAll);
+
+  // eslint-disable-next-line react-hooks/purity -- Date.now() needed for time-based filtering
+  const now = Math.floor(Date.now() / 1000);
+
+  const events = useMemo(() => {
+    const oneWeekFromNow = now + 604800;
+
+    const eventNotes = allEvents
+      .filter((e) => e.event.kind === MAP_NOTE_REPOST_KIND && isEventNote(e))
+      .map((e) => ({
+        ...e,
+        _startTimestamp: getStartTimestamp(e) ?? e.event.created_at,
+      }));
+
+    let filtered: typeof eventNotes;
+    switch (filter) {
+      case "upcoming":
+        filtered = eventNotes.filter((e) => e._startTimestamp >= now);
+        break;
+      case "this-week":
+        filtered = eventNotes.filter(
+          (e) =>
+            e._startTimestamp >= now && e._startTimestamp <= oneWeekFromNow,
+        );
+        break;
+      case "past":
+        filtered = eventNotes.filter((e) => e._startTimestamp < now);
+        break;
+    }
+
+    // Sort by start date: upcoming/this-week ascending, past descending
+    return filtered.sort((a, b) =>
+      filter === "past"
+        ? b._startTimestamp - a._startTimestamp
+        : a._startTimestamp - b._startTimestamp,
+    );
+  }, [allEvents, filter, now]);
+
+  return (
+    <View className="flex-1">
+      <FilterChips
+        chips={EVENT_CHIPS}
+        selectedKey={filter}
+        onSelect={(key) => setFilter(key as EventFilter)}
+      />
+      <FlatList
+        data={events}
+        keyExtractor={(item) => item.event.id}
+        renderItem={({ item }) => <EventCard eventWithMetadata={item} />}
+        ListEmptyComponent={
+          <EmptyState
+            title="No events yet"
+            description="Community events will appear here once they are created"
+          />
+        }
+        contentContainerStyle={{ flexGrow: 1, paddingBottom: 120 }}
+        ItemSeparatorComponent={() => <View className="h-2" />}
+      />
+    </View>
+  );
+}

--- a/nr-app/src/components/discovery/EventsTab.tsx
+++ b/nr-app/src/components/discovery/EventsTab.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { FlatList, View } from "react-native";
+import { FlatList, Pressable, View } from "react-native";
 import {
   getFirstTagValueFromEvent,
   MAP_NOTE_REPOST_KIND,
@@ -8,6 +8,8 @@ import {
 import { EmptyState } from "@/components/EmptyState";
 import EventCard from "./EventCard";
 import { FilterChips, FilterChip } from "./FilterChips";
+import { getPlusCodeFromEvent } from "@/utils/event.utils";
+import { navigateToEvent } from "@/utils/navigation.utils";
 import { useAppSelector } from "@/redux/hooks";
 import {
   eventsSelectors,
@@ -82,7 +84,18 @@ export function EventsTab() {
       <FlatList
         data={events}
         keyExtractor={(item) => item.event.id}
-        renderItem={({ item }) => <EventCard eventWithMetadata={item} />}
+        renderItem={({ item }) => {
+          const plusCode = getPlusCodeFromEvent(item.event);
+          return (
+            <Pressable
+              onPress={() => {
+                if (plusCode) navigateToEvent(plusCode, item.event);
+              }}
+            >
+              <EventCard eventWithMetadata={item} />
+            </Pressable>
+          );
+        }}
         ListEmptyComponent={
           <EmptyState
             title="No events yet"

--- a/nr-app/src/components/discovery/FeedTab.tsx
+++ b/nr-app/src/components/discovery/FeedTab.tsx
@@ -1,0 +1,99 @@
+import { useMemo, useState } from "react";
+import { SectionList, View } from "react-native";
+import { MAP_NOTE_REPOST_KIND } from "@trustroots/nr-common";
+
+import { EmptyState } from "@/components/EmptyState";
+import NotesSingle from "@/components/NotesSingle";
+import { FilterChips, FilterChip } from "./FilterChips";
+import { Text } from "@/components/ui/text";
+import { useAppSelector } from "@/redux/hooks";
+import {
+  eventsSelectors,
+  EventWithMetadata,
+} from "@/redux/slices/events.slice";
+
+type FeedFilter = "all";
+
+const FEED_CHIPS: FilterChip[] = [{ key: "all", label: "All areas" }];
+
+interface Section {
+  title: string;
+  data: EventWithMetadata[];
+}
+
+function groupByTime(events: EventWithMetadata[]): Section[] {
+  const now = Math.floor(Date.now() / 1000);
+  const oneDayAgo = now - 86400;
+  const oneWeekAgo = now - 604800;
+
+  const today: EventWithMetadata[] = [];
+  const thisWeek: EventWithMetadata[] = [];
+  const older: EventWithMetadata[] = [];
+
+  for (const event of events) {
+    const createdAt = event.event.created_at;
+    if (createdAt >= oneDayAgo) {
+      today.push(event);
+    } else if (createdAt >= oneWeekAgo) {
+      thisWeek.push(event);
+    } else {
+      older.push(event);
+    }
+  }
+
+  const sections: Section[] = [];
+  if (today.length > 0) sections.push({ title: "Today", data: today });
+  if (thisWeek.length > 0)
+    sections.push({ title: "This week", data: thisWeek });
+  if (older.length > 0) sections.push({ title: "Older", data: older });
+
+  return sections;
+}
+
+export function FeedTab() {
+  const [filter, setFilter] = useState<FeedFilter>("all");
+  const allEvents = useAppSelector(eventsSelectors.selectAll);
+
+  const mapNotes = useMemo(
+    () =>
+      allEvents
+        .filter((e) => e.event.kind === MAP_NOTE_REPOST_KIND)
+        .sort((a, b) => b.event.created_at - a.event.created_at),
+    [allEvents],
+  );
+
+  const sections = useMemo(() => groupByTime(mapNotes), [mapNotes]);
+
+  return (
+    <View className="flex-1">
+      <FilterChips
+        chips={FEED_CHIPS}
+        selectedKey={filter}
+        onSelect={(key) => setFilter(key as FeedFilter)}
+      />
+      <SectionList
+        sections={sections}
+        keyExtractor={(item) => item.event.id}
+        renderItem={({ item }) => (
+          <NotesSingle eventWithMetadata={item} isSelected={false} />
+        )}
+        renderSectionHeader={({ section: { title } }) => (
+          <View className="px-4 pt-4 pb-2 bg-background">
+            <Text className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+              {title}
+            </Text>
+          </View>
+        )}
+        ListEmptyComponent={
+          <EmptyState
+            title="No notes yet"
+            description="Notes will appear here once they are created"
+          />
+        }
+        contentContainerStyle={{ flexGrow: 1, paddingBottom: 120 }}
+        stickySectionHeadersEnabled={false}
+        ItemSeparatorComponent={() => <View className="h-2" />}
+      />
+    </View>
+  );
+}

--- a/nr-app/src/components/discovery/FeedTab.tsx
+++ b/nr-app/src/components/discovery/FeedTab.tsx
@@ -1,20 +1,15 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { SectionList, View } from "react-native";
 import { MAP_NOTE_REPOST_KIND } from "@trustroots/nr-common";
 
 import { EmptyState } from "@/components/EmptyState";
 import NotesSingle from "@/components/NotesSingle";
-import { FilterChips, FilterChip } from "./FilterChips";
 import { Text } from "@/components/ui/text";
 import { useAppSelector } from "@/redux/hooks";
 import {
   eventsSelectors,
   EventWithMetadata,
 } from "@/redux/slices/events.slice";
-
-type FeedFilter = "all";
-
-const FEED_CHIPS: FilterChip[] = [{ key: "all", label: "All areas" }];
 
 interface Section {
   title: string;
@@ -51,7 +46,6 @@ function groupByTime(events: EventWithMetadata[]): Section[] {
 }
 
 export function FeedTab() {
-  const [filter, setFilter] = useState<FeedFilter>("all");
   const allEvents = useAppSelector(eventsSelectors.selectAll);
 
   const mapNotes = useMemo(
@@ -66,11 +60,6 @@ export function FeedTab() {
 
   return (
     <View className="flex-1">
-      <FilterChips
-        chips={FEED_CHIPS}
-        selectedKey={filter}
-        onSelect={(key) => setFilter(key as FeedFilter)}
-      />
       <SectionList
         sections={sections}
         keyExtractor={(item) => item.event.id}

--- a/nr-app/src/components/discovery/FeedTab.tsx
+++ b/nr-app/src/components/discovery/FeedTab.tsx
@@ -1,10 +1,12 @@
 import { useMemo } from "react";
-import { SectionList, View } from "react-native";
+import { Pressable, SectionList, View } from "react-native";
 import { MAP_NOTE_REPOST_KIND } from "@trustroots/nr-common";
 
 import { EmptyState } from "@/components/EmptyState";
 import NotesSingle from "@/components/NotesSingle";
 import { Text } from "@/components/ui/text";
+import { getPlusCodeFromEvent } from "@/utils/event.utils";
+import { navigateToEvent } from "@/utils/navigation.utils";
 import { useAppSelector } from "@/redux/hooks";
 import {
   eventsSelectors,
@@ -63,9 +65,18 @@ export function FeedTab() {
       <SectionList
         sections={sections}
         keyExtractor={(item) => item.event.id}
-        renderItem={({ item }) => (
-          <NotesSingle eventWithMetadata={item} isSelected={false} />
-        )}
+        renderItem={({ item }) => {
+          const plusCode = getPlusCodeFromEvent(item.event);
+          return (
+            <Pressable
+              onPress={() => {
+                if (plusCode) navigateToEvent(plusCode, item.event);
+              }}
+            >
+              <NotesSingle eventWithMetadata={item} isSelected={false} />
+            </Pressable>
+          );
+        }}
         renderSectionHeader={({ section: { title } }) => (
           <View className="px-4 pt-4 pb-2 bg-background">
             <Text className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">

--- a/nr-app/src/components/discovery/FilterChips.tsx
+++ b/nr-app/src/components/discovery/FilterChips.tsx
@@ -1,4 +1,4 @@
-import { ScrollView, Pressable } from "react-native";
+import { ScrollView, Pressable, View } from "react-native";
 import { Text } from "@/components/ui/text";
 
 export interface FilterChip {
@@ -19,31 +19,35 @@ export function FilterChips({
   onSelect,
 }: FilterChipsProps) {
   return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      contentContainerClassName="px-4 py-2 gap-2"
-    >
-      {chips.map((chip) => {
-        const isSelected = chip.key === selectedKey;
-        return (
-          <Pressable
-            key={chip.key}
-            onPress={() => onSelect(chip.key)}
-            className={`px-3 py-1.5 rounded-full border ${
-              isSelected ? "bg-primary border-primary" : "bg-card border-border"
-            }`}
-          >
-            <Text
-              className={`text-sm font-medium ${
-                isSelected ? "text-primary-foreground" : "text-foreground"
+    <View className="flex-shrink-0">
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerClassName="px-4 py-2 gap-2 items-center"
+      >
+        {chips.map((chip) => {
+          const isSelected = chip.key === selectedKey;
+          return (
+            <Pressable
+              key={chip.key}
+              onPress={() => onSelect(chip.key)}
+              className={`px-3 py-1 rounded-full border ${
+                isSelected
+                  ? "bg-primary border-primary"
+                  : "bg-card border-border"
               }`}
             >
-              {chip.emoji ? `${chip.emoji} ${chip.label}` : chip.label}
-            </Text>
-          </Pressable>
-        );
-      })}
-    </ScrollView>
+              <Text
+                className={`text-sm font-medium ${
+                  isSelected ? "text-primary-foreground" : "text-foreground"
+                }`}
+              >
+                {chip.emoji ? `${chip.emoji} ${chip.label}` : chip.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+    </View>
   );
 }

--- a/nr-app/src/components/discovery/FilterChips.tsx
+++ b/nr-app/src/components/discovery/FilterChips.tsx
@@ -1,0 +1,49 @@
+import { ScrollView, Pressable } from "react-native";
+import { Text } from "@/components/ui/text";
+
+export interface FilterChip {
+  key: string;
+  label: string;
+  emoji?: string;
+}
+
+interface FilterChipsProps {
+  chips: FilterChip[];
+  selectedKey: string;
+  onSelect: (key: string) => void;
+}
+
+export function FilterChips({
+  chips,
+  selectedKey,
+  onSelect,
+}: FilterChipsProps) {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerClassName="px-4 py-2 gap-2"
+    >
+      {chips.map((chip) => {
+        const isSelected = chip.key === selectedKey;
+        return (
+          <Pressable
+            key={chip.key}
+            onPress={() => onSelect(chip.key)}
+            className={`px-3 py-1.5 rounded-full border ${
+              isSelected ? "bg-primary border-primary" : "bg-card border-border"
+            }`}
+          >
+            <Text
+              className={`text-sm font-medium ${
+                isSelected ? "text-primary-foreground" : "text-foreground"
+              }`}
+            >
+              {chip.emoji ? `${chip.emoji} ${chip.label}` : chip.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}

--- a/nr-app/src/components/discovery/SignalsTab.tsx
+++ b/nr-app/src/components/discovery/SignalsTab.tsx
@@ -27,7 +27,7 @@ const SIGNAL_CHIPS: FilterChip[] = [
 
 function isSignalEvent(event: EventWithMetadata): boolean {
   return event.event.tags.some(
-    (tag) => tag[0] === "t" && tag[1] !== "signal" && tag[1] !== undefined,
+    (tag) => tag[0] === "t" && tag[1] === "signal",
   );
 }
 

--- a/nr-app/src/components/discovery/SignalsTab.tsx
+++ b/nr-app/src/components/discovery/SignalsTab.tsx
@@ -1,0 +1,91 @@
+import { useMemo, useState } from "react";
+import { FlatList, View } from "react-native";
+import {
+  getFirstTagValueFromEvent,
+  MAP_NOTE_REPOST_KIND,
+  NOSTR_EXPIRATION_TAG_NAME,
+} from "@trustroots/nr-common";
+
+import { EmptyState } from "@/components/EmptyState";
+import SignalMiniCard from "@/components/SignalMiniCard";
+import { FilterChips, FilterChip } from "./FilterChips";
+import { SIGNAL_INTENTS } from "@/constants/signals";
+import { useAppSelector } from "@/redux/hooks";
+import {
+  eventsSelectors,
+  EventWithMetadata,
+} from "@/redux/slices/events.slice";
+
+const SIGNAL_CHIPS: FilterChip[] = [
+  { key: "all", label: "All" },
+  ...SIGNAL_INTENTS.map((intent) => ({
+    key: intent.key,
+    label: intent.label,
+    emoji: intent.emoji,
+  })),
+];
+
+function isSignalEvent(event: EventWithMetadata): boolean {
+  return event.event.tags.some(
+    (tag) => tag[0] === "t" && tag[1] !== "signal" && tag[1] !== undefined,
+  );
+}
+
+function isUnexpired(event: EventWithMetadata): boolean {
+  const expirationString = getFirstTagValueFromEvent(
+    event.event,
+    NOSTR_EXPIRATION_TAG_NAME,
+  );
+  if (!expirationString) return true;
+  const expiration = parseInt(expirationString);
+  const now = Math.floor(Date.now() / 1000);
+  return expiration > now;
+}
+
+function hasIntentType(event: EventWithMetadata, intentKey: string): boolean {
+  return event.event.tags.some((tag) => tag[0] === "t" && tag[1] === intentKey);
+}
+
+export function SignalsTab() {
+  const [filter, setFilter] = useState("all");
+  const allEvents = useAppSelector(eventsSelectors.selectAll);
+
+  const signals = useMemo(() => {
+    const activeSignals = allEvents
+      .filter(
+        (e) =>
+          e.event.kind === MAP_NOTE_REPOST_KIND &&
+          isSignalEvent(e) &&
+          isUnexpired(e),
+      )
+      .sort((a, b) => b.event.created_at - a.event.created_at);
+
+    if (filter === "all") return activeSignals;
+    return activeSignals.filter((e) => hasIntentType(e, filter));
+  }, [allEvents, filter]);
+
+  return (
+    <View className="flex-1">
+      <FilterChips
+        chips={SIGNAL_CHIPS}
+        selectedKey={filter}
+        onSelect={setFilter}
+      />
+      <FlatList
+        data={signals}
+        keyExtractor={(item) => item.event.id}
+        renderItem={({ item }) => (
+          <SignalMiniCard signal={item} onClose={() => {}} />
+        )}
+        ListEmptyComponent={
+          <EmptyState
+            title="No active signals"
+            description="Signals from nearby travelers will appear here"
+          />
+        }
+        contentContainerStyle={{ flexGrow: 1, paddingBottom: 120 }}
+        ItemSeparatorComponent={() => <View className="h-1" />}
+      />
+    </View>
+  );
+}

--- a/nr-app/src/components/discovery/SignalsTab.tsx
+++ b/nr-app/src/components/discovery/SignalsTab.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { FlatList, View } from "react-native";
+import { FlatList, Pressable, View } from "react-native";
 import {
   getFirstTagValueFromEvent,
   MAP_NOTE_REPOST_KIND,
@@ -10,6 +10,8 @@ import { EmptyState } from "@/components/EmptyState";
 import SignalMiniCard from "@/components/SignalMiniCard";
 import { FilterChips, FilterChip } from "./FilterChips";
 import { SIGNAL_INTENTS } from "@/constants/signals";
+import { getPlusCodeFromEvent } from "@/utils/event.utils";
+import { navigateToEvent } from "@/utils/navigation.utils";
 import { useAppSelector } from "@/redux/hooks";
 import {
   eventsSelectors,
@@ -74,9 +76,18 @@ export function SignalsTab() {
       <FlatList
         data={signals}
         keyExtractor={(item) => item.event.id}
-        renderItem={({ item }) => (
-          <SignalMiniCard signal={item} onClose={() => {}} />
-        )}
+        renderItem={({ item }) => {
+          const plusCode = getPlusCodeFromEvent(item.event);
+          return (
+            <Pressable
+              onPress={() => {
+                if (plusCode) navigateToEvent(plusCode, item.event);
+              }}
+            >
+              <SignalMiniCard signal={item} onClose={() => {}} />
+            </Pressable>
+          );
+        }}
         ListEmptyComponent={
           <EmptyState
             title="No active signals"


### PR DESCRIPTION
## Summary
- Reworks the list screen into a tabbed discovery experience with Feed, Signals, and Events tabs
- Each tab has its own filtering (signal intents, event timeframes) via filter pill chips
- Fixes signal detection to correctly match events with the `["t", "signal"]` marker tag
- Fixes filter pills stretching tall when the list is empty

## Test plan
- [ ] Open the list/discover screen and verify three tabs render (Feed, Signals, Events)
- [ ] Switch between tabs and confirm correct content appears
- [ ] On Signals tab, verify only actual signals show (not regular map notes)
- [ ] On Events tab, verify time-based filters (Upcoming, This week, Past) work
- [ ] Verify filter pills maintain compact height when lists are empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)