### PR TITLE
Show user location on map

### DIFF
--- a/nr-app/src/components/MapPlusCodes.tsx
+++ b/nr-app/src/components/MapPlusCodes.tsx
@@ -85,13 +85,9 @@ const selectPlusCodesWithState = createSelector(
   },
 );
 
-// Show the user's location dot when zoomed in past this threshold
-const USER_LOCATION_LAT_DELTA_THRESHOLD = 2;
-
 export default function MapPlusCodes() {
   const dispatch = useAppDispatch();
   const [isMapReady, setIsMapReady] = useState(false);
-  const [showUserLocation, setShowUserLocation] = useState(false);
   const [locationPermissionGranted, setLocationPermissionGranted] =
     useState(false);
 
@@ -200,10 +196,6 @@ export default function MapPlusCodes() {
         log.debug("#mzWdGm regionChange plusCode length", length);
         // Save the region so it can be restored when the app reopens
         dispatch(mapActions.setSavedRegion(region));
-        // Show user location dot when zoomed in enough
-        setShowUserLocation(
-          region.latitudeDelta < USER_LOCATION_LAT_DELTA_THRESHOLD,
-        );
       },
     [dispatch],
   );
@@ -215,7 +207,7 @@ export default function MapPlusCodes() {
         style={styles.map}
         rotateEnabled={false}
         pitchEnabled={false}
-        showsUserLocation={locationPermissionGranted && showUserLocation}
+        showsUserLocation={locationPermissionGranted}
         onRegionChangeComplete={handleMapRegionChange}
         initialRegion={savedRegion}
         provider={getMapProvider()}

--- a/nr-app/src/components/MapPlusCodes.tsx
+++ b/nr-app/src/components/MapPlusCodes.tsx
@@ -23,6 +23,7 @@ import { StyleSheet, TouchableOpacity, View } from "react-native";
 import MapView, { Polygon, Region } from "react-native-maps";
 // @ts-ignore
 import { getCurrentLocation } from "@/utils/location";
+import * as Location from "expo-location";
 import { FontAwesome } from "@expo/vector-icons";
 import { createSelector } from "reselect";
 
@@ -84,9 +85,15 @@ const selectPlusCodesWithState = createSelector(
   },
 );
 
+// Show the user's location dot when zoomed in past this threshold
+const USER_LOCATION_LAT_DELTA_THRESHOLD = 2;
+
 export default function MapPlusCodes() {
   const dispatch = useAppDispatch();
   const [isMapReady, setIsMapReady] = useState(false);
+  const [showUserLocation, setShowUserLocation] = useState(false);
+  const [locationPermissionGranted, setLocationPermissionGranted] =
+    useState(false);
 
   const plusCodesWithState = useAppSelector(selectPlusCodesWithState);
   const selectedPlusCode = useAppSelector(mapSelectors.selectSelectedPlusCode);
@@ -103,6 +110,21 @@ export default function MapPlusCodes() {
   const savedRegion = useAppSelector(mapSelectors.selectSavedRegion);
 
   const mapViewRef = useRef<MapView>(null);
+
+  // Request location permission on mount so we can show the user's location dot
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { status } =
+        await Location.requestForegroundPermissionsAsync();
+      if (!cancelled) {
+        setLocationPermissionGranted(status === "granted");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Clean up the map ref on unmount
   useEffect(() => {
@@ -178,6 +200,10 @@ export default function MapPlusCodes() {
         log.debug("#mzWdGm regionChange plusCode length", length);
         // Save the region so it can be restored when the app reopens
         dispatch(mapActions.setSavedRegion(region));
+        // Show user location dot when zoomed in enough
+        setShowUserLocation(
+          region.latitudeDelta < USER_LOCATION_LAT_DELTA_THRESHOLD,
+        );
       },
     [dispatch],
   );
@@ -189,6 +215,7 @@ export default function MapPlusCodes() {
         style={styles.map}
         rotateEnabled={false}
         pitchEnabled={false}
+        showsUserLocation={locationPermissionGranted && showUserLocation}
         onRegionChangeComplete={handleMapRegionChange}
         initialRegion={savedRegion}
         provider={getMapProvider()}

--- a/nr-app/src/components/MapPlusCodes.tsx
+++ b/nr-app/src/components/MapPlusCodes.tsx
@@ -23,7 +23,6 @@ import { StyleSheet, TouchableOpacity, View } from "react-native";
 import MapView, { Polygon, Region } from "react-native-maps";
 // @ts-ignore
 import { getCurrentLocation } from "@/utils/location";
-import * as Location from "expo-location";
 import { FontAwesome } from "@expo/vector-icons";
 import { createSelector } from "reselect";
 
@@ -107,21 +106,6 @@ export default function MapPlusCodes() {
 
   const mapViewRef = useRef<MapView>(null);
 
-  // Request location permission on mount so we can show the user's location dot
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const { status } =
-        await Location.requestForegroundPermissionsAsync();
-      if (!cancelled) {
-        setLocationPermissionGranted(status === "granted");
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
   // Clean up the map ref on unmount
   useEffect(() => {
     return () => {
@@ -166,6 +150,7 @@ export default function MapPlusCodes() {
   const handleLocationPress = async () => {
     const location = await getCurrentLocation();
     if (location) {
+      setLocationPermissionGranted(true);
       dispatch(
         mapActions.setCurrentMapLocation({
           latitude: location.coords.latitude,
@@ -182,7 +167,10 @@ export default function MapPlusCodes() {
         ),
       );
       dispatch(mapActions.centerMapOnCurrentLocationComplete());
+      return;
     }
+
+    setLocationPermissionGranted(false);
   };
 
   const handleMapRegionChange = useMemo(


### PR DESCRIPTION
## Summary
- Shows the native blue location dot on the map when location permission is granted
- Requests foreground location permission on mount
- Visible at all zoom levels

Closes #189

## Test plan
- [ ] Open the app, grant location permission when prompted
- [ ] Verify blue dot appears at your current location
- [ ] Zoom in and out — dot should remain visible at all levels