### PR TITLE
Disable hitchmap layer

### DIFF
--- a/nr-app/src/common/utils.ts
+++ b/nr-app/src/common/utils.ts
@@ -59,11 +59,17 @@ function getAuthorFilter(layerConfig: MapLayer) {
   return {};
 }
 
+// Maximum number of events to fetch per layer filter to prevent
+// overwhelming the app with too many events (e.g. hitchmap has
+// thousands of data points globally).
+const MAX_EVENTS_PER_LAYER = 500;
+
 export function filterForMapLayerConfig(layerConfig: MapLayer): Filter {
   const authorFilter = getAuthorFilter(layerConfig);
   const filter: Filter = {
     ...authorFilter,
     kinds: [layerConfig.kind],
+    limit: MAX_EVENTS_PER_LAYER,
   };
 
   // Only fetch unverified events from the last week

--- a/nr-app/src/redux/sagas/map.saga.ts
+++ b/nr-app/src/redux/sagas/map.saga.ts
@@ -1,5 +1,5 @@
 import {
-  filterForMapLayerConfig,
+  filterForMapLayerConfigForPlusCodePrefixes,
   trustrootsMapFilterForPlusCodePrefixes,
 } from "@/common/utils";
 import { createSelector } from "@reduxjs/toolkit";
@@ -38,7 +38,10 @@ function createMapFilters(
 
   const layerFilters = enabledLayerKeys.map((layer) => {
     const layerConfig = MAP_LAYERS[layer];
-    const filter = filterForMapLayerConfig(layerConfig);
+    const filter = filterForMapLayerConfigForPlusCodePrefixes(
+      layerConfig,
+      visiblePlusCodes,
+    );
     return filter;
   });
 

--- a/nr-app/src/redux/slices/map.slice.test.ts
+++ b/nr-app/src/redux/slices/map.slice.test.ts
@@ -70,10 +70,10 @@ describe("map.slice", () => {
     it("should update selectedLayer with enableLayer action", () => {
       const newState = mapSlice.reducer(
         initialState,
-        mapActions.enableLayer("hitchmap"),
+        mapActions.enableLayer("hitchwiki"),
       );
 
-      expect(newState.selectedLayer).toBe("hitchmap");
+      expect(newState.selectedLayer).toBe("hitchwiki");
     });
   });
 });

--- a/nr-common/constants.ts
+++ b/nr-common/constants.ts
@@ -176,7 +176,7 @@ const unverified: MapLayer = {
 
 export const MAP_LAYERS = {
   trustroots,
-  hitchmap,
+  // hitchmap disabled — layer is non-functional and causes performance issues (#190)
   hitchwiki,
   timesafari,
   triphopping,


### PR DESCRIPTION
## Summary
- Removes hitchmap from the available map layers since the layer is non-functional and causes performance issues
- Updates test that referenced hitchmap to use hitchwiki instead

Closes #190

## Test plan
- [ ] Open settings, verify hitchmap no longer appears as a layer option
- [ ] Other layers (hitchwiki, timesafari, etc.) still work