### PR TITLE
[codex] Broaden nr-app test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules
 .pnpm-store
+coverage
+*/coverage
 .env
 .env.local
 .DS_Store

--- a/nr-app/app/(main)/(map)/list.test.tsx
+++ b/nr-app/app/(main)/(map)/list.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent } from "@testing-library/react-native";
+
+import ListScreen from "./list";
+import { renderWithProviders } from "@/test/test-utils";
+
+describe("ListScreen", () => {
+  it("switches between feed, signals, and events empty states", () => {
+    const { getByText } = renderWithProviders(<ListScreen />);
+
+    expect(getByText("Discover")).toBeTruthy();
+    expect(getByText("No notes yet")).toBeTruthy();
+
+    fireEvent.press(getByText("Signals"));
+    expect(getByText("No active signals")).toBeTruthy();
+
+    fireEvent.press(getByText("Events"));
+    expect(getByText("No events yet")).toBeTruthy();
+
+    fireEvent.press(getByText("Feed"));
+    expect(getByText("No notes yet")).toBeTruthy();
+  });
+});

--- a/nr-app/app/index.test.tsx
+++ b/nr-app/app/index.test.tsx
@@ -1,0 +1,63 @@
+import { Redirect } from "expo-router";
+import { waitFor, screen } from "@testing-library/react-native";
+
+import IndexRoute from "./index";
+import { ROUTES } from "@/constants/routes";
+import { renderWithProviders } from "@/test/test-utils";
+
+const mockRedirect = Redirect as jest.Mock;
+
+describe("IndexRoute", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows a loading state while settings are hydrating", () => {
+    renderWithProviders(<IndexRoute />, {
+      preloadedState: {
+        settings: {
+          isDataLoaded: false,
+        },
+      },
+    });
+
+    expect(screen.UNSAFE_getByType("ActivityIndicator")).toBeTruthy();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("sends first-time users to the welcome screen", async () => {
+    renderWithProviders(<IndexRoute />, {
+      preloadedState: {
+        settings: {
+          isDataLoaded: true,
+          hasBeenOpenedBefore: false,
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(mockRedirect).toHaveBeenCalledWith(
+        { href: ROUTES.WELCOME },
+        undefined,
+      );
+    });
+  });
+
+  it("sends returning users without identity to onboarding", async () => {
+    renderWithProviders(<IndexRoute />, {
+      preloadedState: {
+        settings: {
+          isDataLoaded: true,
+          hasBeenOpenedBefore: true,
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(mockRedirect).toHaveBeenCalledWith(
+        { href: ROUTES.ONBOARDING },
+        undefined,
+      );
+    });
+  });
+});

--- a/nr-app/app/onboarding/identity.test.tsx
+++ b/nr-app/app/onboarding/identity.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent } from "@testing-library/react-native";
+import { useRouter } from "expo-router";
+
+import OnboardingIdentityScreen from "./identity";
+import { ROUTES } from "@/constants/routes";
+import { renderWithProviders } from "@/test/test-utils";
+
+const mockUseRouter = useRouter as jest.Mock;
+
+describe("OnboardingIdentityScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("continues to the Trustroots username step", () => {
+    const push = jest.fn();
+    mockUseRouter.mockReturnValue({
+      push,
+      replace: jest.fn(),
+      back: jest.fn(),
+      canGoBack: () => false,
+    });
+
+    const { getByText } = renderWithProviders(<OnboardingIdentityScreen />);
+
+    fireEvent.press(getByText("Continue"));
+
+    expect(push).toHaveBeenCalledWith("/onboarding/trustroots");
+  });
+
+  it("shows skip when enabled and navigates home", () => {
+    const push = jest.fn();
+    mockUseRouter.mockReturnValue({
+      push,
+      replace: jest.fn(),
+      back: jest.fn(),
+      canGoBack: () => false,
+    });
+
+    const { getByText } = renderWithProviders(<OnboardingIdentityScreen />, {
+      preloadedState: {
+        settings: {
+          useSkipOnboarding: true,
+        },
+      },
+    });
+
+    fireEvent.press(getByText("Skip"));
+
+    expect(push).toHaveBeenCalledWith(ROUTES.HOME);
+  });
+
+  it("hides skip when skip onboarding is disabled", () => {
+    mockUseRouter.mockReturnValue({
+      push: jest.fn(),
+      replace: jest.fn(),
+      back: jest.fn(),
+      canGoBack: () => false,
+    });
+
+    const { queryByText } = renderWithProviders(<OnboardingIdentityScreen />, {
+      preloadedState: {
+        settings: {
+          useSkipOnboarding: false,
+        },
+      },
+    });
+
+    expect(queryByText("Skip")).toBeNull();
+  });
+});

--- a/nr-app/app/welcome.test.tsx
+++ b/nr-app/app/welcome.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render } from "@testing-library/react-native";
+import { useRouter } from "expo-router";
+
+import WelcomeScreen from "./welcome";
+
+const mockUseRouter = useRouter as jest.Mock;
+
+describe("WelcomeScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("moves users into onboarding from the welcome screen", () => {
+    const replace = jest.fn();
+    mockUseRouter.mockReturnValue({
+      push: jest.fn(),
+      replace,
+      back: jest.fn(),
+    });
+
+    const { getByText } = render(<WelcomeScreen />);
+
+    expect(getByText("Welcome to Nostroots")).toBeTruthy();
+    fireEvent.press(getByText("Get Started"));
+
+    expect(replace).toHaveBeenCalledWith("/onboarding");
+  });
+});

--- a/nr-app/package.json
+++ b/nr-app/package.json
@@ -9,6 +9,7 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "jest",
+    "test:coverage": "jest --watchman=false --coverage",
     "test:watch": "jest --watchAll",
     "lint": "eslint .",
     "prepare": "cd .. && husky nr-app/.husky",
@@ -29,7 +30,7 @@
       "^@noble/hashes/utils$": "<rootDir>/../node_modules/@noble/hashes/utils.js"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|nativewind|@trustroots/nr-common|@reduxjs/toolkit|immer|redux-persist|redux-devtools-expo-dev-plugin|nostr-tools|@noble/.*|@scure/.*)"
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|nativewind|@trustroots/nr-common|@reduxjs/toolkit|immer|react-redux|redux-persist|redux-devtools-expo-dev-plugin|nostr-tools|@noble/.*|@scure/.*)"
     ]
   },
   "dependencies": {

--- a/nr-app/src/components/MapAddNoteModal.test.tsx
+++ b/nr-app/src/components/MapAddNoteModal.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, waitFor } from "@testing-library/react-native";
+import Toast from "react-native-root-toast";
+
+import MapAddNoteModal from "./MapAddNoteModal";
+import { renderWithProviders } from "@/test/test-utils";
+
+const openModalState = {
+  map: {
+    isAddNoteModalOpen: true,
+    selectedLatLng: {
+      latitude: 52.52,
+      longitude: 13.405,
+    },
+  },
+};
+
+describe("MapAddNoteModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not publish an empty note", () => {
+    const { getByText, store } = renderWithProviders(<MapAddNoteModal />, {
+      preloadedState: openModalState,
+    });
+    const dispatchSpy = jest.spyOn(store, "dispatch");
+
+    fireEvent.press(getByText("Add Note"));
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "publish/eventTemplate/request" }),
+    );
+  });
+
+  it("dispatches a map note publish request for valid content", async () => {
+    const { getByPlaceholderText, getByText, store } = renderWithProviders(
+      <MapAddNoteModal />,
+      {
+        preloadedState: openModalState,
+      },
+    );
+    const dispatchSpy = jest.spyOn(store, "dispatch");
+
+    fireEvent.changeText(
+      getByPlaceholderText("Enter your note"),
+      "Hosting tea in Berlin",
+    );
+    fireEvent.press(getByText("Add Note"));
+
+    await waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "publish/eventTemplate/request",
+          payload: {
+            eventTemplate: expect.objectContaining({
+              content: "Hosting tea in Berlin",
+              kind: 30397,
+            }),
+          },
+        }),
+      );
+      expect(Toast.show).toHaveBeenCalledWith(
+        "Note added successfully",
+        expect.objectContaining({ duration: Toast.durations.LONG }),
+      );
+    });
+  });
+});

--- a/nr-app/src/components/NotificationSubscription.test.tsx
+++ b/nr-app/src/components/NotificationSubscription.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, waitFor } from "@testing-library/react-native";
+import Toast from "react-native-root-toast";
+
+import NotificationSubscription from "./NotificationSubscription";
+import {
+  subscribeToPlusCode,
+  unsubscribeFromPlusCode,
+} from "@/redux/actions/notifications.actions";
+import { filterForPlusCode } from "@/utils/notifications.utils";
+import { createTestStore, renderWithProviders } from "@/test/test-utils";
+import { TEST_PLUS_CODE } from "@/test/fixtures";
+
+describe("NotificationSubscription", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("dispatches a subscribe request for the selected plus code", async () => {
+    const store = createTestStore({
+      map: {
+        selectedPlusCode: TEST_PLUS_CODE,
+      },
+    });
+    const dispatchSpy = jest.spyOn(store, "dispatch");
+    const { getAllByText } = renderWithProviders(<NotificationSubscription />, {
+      store,
+    });
+
+    fireEvent.press(getAllByText("Subscribe")[1]);
+
+    await waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: subscribeToPlusCode(TEST_PLUS_CODE).type,
+          payload: { plusCode: TEST_PLUS_CODE },
+        }),
+      );
+      expect(Toast.show).toHaveBeenCalledWith(
+        "Successfully subscribed",
+        expect.objectContaining({ duration: Toast.durations.LONG }),
+      );
+    });
+  });
+
+  it("shows unsubscribe for an exact subscription and dispatches removal", async () => {
+    const store = createTestStore({
+      map: {
+        selectedPlusCode: TEST_PLUS_CODE,
+      },
+      notifications: {
+        filters: [{ filter: filterForPlusCode(TEST_PLUS_CODE) }],
+      },
+    });
+    const dispatchSpy = jest.spyOn(store, "dispatch");
+    const { getByText } = renderWithProviders(<NotificationSubscription />, {
+      store,
+    });
+
+    expect(
+      getByText("You are subscribed to notifications for this plus code."),
+    ).toBeTruthy();
+
+    fireEvent.press(getByText("Unsubscribe"));
+
+    await waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: unsubscribeFromPlusCode(TEST_PLUS_CODE).type,
+          payload: { plusCode: TEST_PLUS_CODE },
+        }),
+      );
+      expect(Toast.show).toHaveBeenCalledWith(
+        "Successfully unsubscribed",
+        expect.objectContaining({ duration: Toast.durations.LONG }),
+      );
+    });
+  });
+});

--- a/nr-app/src/redux/slices/events.slice.test.ts
+++ b/nr-app/src/redux/slices/events.slice.test.ts
@@ -1,0 +1,63 @@
+import { NOSTR_EXPIRATION_TAG_NAME } from "@trustroots/nr-common";
+
+import { createMapNote } from "@/test/fixtures";
+import {
+  eventsActions,
+  eventsSelectors,
+  eventsSlice,
+  setAllEventsWithMetadata,
+} from "./events.slice";
+
+describe("eventsSlice", () => {
+  it("selects map notes and sorts them by time", () => {
+    const oldNote = createMapNote({
+      id: "1".repeat(64),
+      created_at: 100,
+      content: "older",
+    });
+    const newNote = createMapNote({
+      id: "2".repeat(64),
+      created_at: 200,
+      content: "newer",
+    });
+    const state = {
+      events: eventsSlice.reducer(
+        undefined,
+        setAllEventsWithMetadata([oldNote, newNote]),
+      ),
+    };
+
+    expect(eventsSelectors.selectMapNotes(state)).toHaveLength(2);
+    const sortedContents = eventsSelectors
+      .selectEventsSortedByTimeFactory("newest")(state)
+      .map(({ event }) => event.content);
+    expect(sortedContents).toEqual(["newer", "older"]);
+  });
+
+  it("flushes expired events while preserving active events", () => {
+    const expired = createMapNote({
+      id: "3".repeat(64),
+      tags: [[NOSTR_EXPIRATION_TAG_NAME, "99"]],
+      content: "expired",
+    });
+    const active = createMapNote({
+      id: "4".repeat(64),
+      tags: [[NOSTR_EXPIRATION_TAG_NAME, "101"]],
+      content: "active",
+    });
+    const loaded = eventsSlice.reducer(
+      undefined,
+      setAllEventsWithMetadata([expired, active]),
+    );
+
+    const flushed = eventsSlice.reducer(
+      loaded,
+      eventsActions.flushExpiredEvents({ currentTimestampSeconds: 100 }),
+    );
+
+    expect(eventsSelectors.selectAll({ events: flushed })).toHaveLength(1);
+    expect(
+      eventsSelectors.selectAll({ events: flushed })[0].event.content,
+    ).toBe("active");
+  });
+});

--- a/nr-app/src/redux/slices/keystore.slice.test.ts
+++ b/nr-app/src/redux/slices/keystore.slice.test.ts
@@ -1,0 +1,53 @@
+import {
+  clearKeystoreState,
+  keystoreSelectors,
+  keystoreSlice,
+  setKeystoreHydrated,
+  setPublicKeyHex,
+} from "./keystore.slice";
+import { TEST_PUBKEY } from "@/test/fixtures";
+
+describe("keystoreSlice", () => {
+  it("stores public key state after a key is loaded", () => {
+    const state = keystoreSlice.reducer(
+      undefined,
+      setPublicKeyHex({
+        publicKeyHex: TEST_PUBKEY,
+        hasMnemonic: true,
+      }),
+    );
+
+    expect(state.isLoaded).toBe(true);
+    expect(state.hasPrivateKeyHexInSecureStorage).toBe(true);
+    expect(state.hasPrivateKeyMnemonicInSecureStorage).toBe(true);
+    expect(state.publicKeyHex).toBe(TEST_PUBKEY);
+    expect(state.publicKeyNpub).toMatch(/^npub/);
+  });
+
+  it("clears private key flags while keeping hydration complete", () => {
+    const loaded = keystoreSlice.reducer(
+      undefined,
+      setPublicKeyHex({
+        publicKeyHex: TEST_PUBKEY,
+        hasMnemonic: false,
+      }),
+    );
+    const cleared = keystoreSlice.reducer(loaded, clearKeystoreState());
+
+    expect(
+      keystoreSelectors.selectHasPrivateKeyInSecureStorage({
+        keystore: cleared,
+      }),
+    ).toBe(false);
+    expect(
+      keystoreSelectors.selectIsKeystoreLoaded({ keystore: cleared }),
+    ).toBe(true);
+  });
+
+  it("marks the keystore as hydrated even without a key", () => {
+    const state = keystoreSlice.reducer(undefined, setKeystoreHydrated());
+
+    expect(state.isLoaded).toBe(true);
+    expect(state.hasPrivateKeyHexInSecureStorage).toBe(false);
+  });
+});

--- a/nr-app/src/redux/slices/notifications.slice.test.ts
+++ b/nr-app/src/redux/slices/notifications.slice.test.ts
@@ -1,0 +1,39 @@
+import {
+  notificationSelectors,
+  notificationsActions,
+  notificationsSlice,
+} from "./notifications.slice";
+import { filterForPlusCode } from "@/utils/notifications.utils";
+import { TEST_PLUS_CODE } from "@/test/fixtures";
+
+describe("notificationsSlice", () => {
+  it("deduplicates notification filters", () => {
+    const filter = { filter: filterForPlusCode(TEST_PLUS_CODE) };
+    const once = notificationsSlice.reducer(
+      undefined,
+      notificationsActions.addFilter(filter),
+    );
+    const twice = notificationsSlice.reducer(
+      once,
+      notificationsActions.addFilter(filter),
+    );
+
+    expect(twice.filters).toHaveLength(1);
+  });
+
+  it("adds and removes expo push tokens", () => {
+    const withToken = notificationsSlice.reducer(
+      undefined,
+      notificationsActions.addExpoPushToken("ExponentPushToken[test]"),
+    );
+    const withoutToken = notificationsSlice.reducer(
+      withToken,
+      notificationsActions.removeExpoPushToken("ExponentPushToken[test]"),
+    );
+
+    expect(
+      notificationSelectors.selectExpoPushToken({ notifications: withToken }),
+    ).toBe("ExponentPushToken[test]");
+    expect(withoutToken.tokens).toEqual([]);
+  });
+});

--- a/nr-app/src/redux/slices/settings.slice.test.ts
+++ b/nr-app/src/redux/slices/settings.slice.test.ts
@@ -1,0 +1,33 @@
+import {
+  selectFeatureFlags,
+  settingsActions,
+  settingsSlice,
+} from "./settings.slice";
+
+describe("settingsSlice", () => {
+  it("toggles developer test features", () => {
+    const state = settingsSlice.reducer(
+      undefined,
+      settingsActions.toggleTestFeatures(),
+    );
+
+    expect(state.areTestFeaturesEnabled).toBe(true);
+  });
+
+  it("selects feature flags used by routing and onboarding", () => {
+    const state = {
+      settings: settingsSlice.reducer(
+        undefined,
+        settingsActions.setForceOnboarding(true),
+      ),
+    };
+
+    expect(
+      selectFeatureFlags(state as Parameters<typeof selectFeatureFlags>[0]),
+    ).toEqual({
+      useSkipOnboarding: true,
+      forceOnboarding: true,
+      forceWelcome: false,
+    });
+  });
+});

--- a/nr-app/src/test/fixtures.ts
+++ b/nr-app/src/test/fixtures.ts
@@ -1,0 +1,69 @@
+import {
+  Event,
+  getPlusCodeAndPlusCodePrefixTags,
+  MAP_NOTE_REPOST_KIND,
+  TRUSTROOTS_PROFILE_KIND,
+} from "@trustroots/nr-common";
+
+import { EventWithMetadata } from "@/redux/slices/events.slice";
+
+export const TEST_PUBKEY =
+  "1111111111111111111111111111111111111111111111111111111111111111";
+export const TEST_RELAY = "wss://relay.example";
+export const TEST_PLUS_CODE = "9F4M0000+";
+
+function hex(seed: string, length: number): string {
+  return seed.repeat(length).slice(0, length);
+}
+
+export function createNostrEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: hex("a", 64),
+    pubkey: TEST_PUBKEY,
+    created_at: 1_800_000_000,
+    kind: MAP_NOTE_REPOST_KIND,
+    tags: getPlusCodeAndPlusCodePrefixTags(TEST_PLUS_CODE),
+    content: "A useful map note",
+    sig: hex("b", 128),
+    ...overrides,
+  };
+}
+
+export function createEventWithMetadata(
+  overrides: Partial<Event> = {},
+): EventWithMetadata {
+  return {
+    event: createNostrEvent(overrides),
+    metadata: {
+      seenOnRelays: [TEST_RELAY],
+    },
+  };
+}
+
+export function createMapNote(
+  overrides: Partial<Event> = {},
+): EventWithMetadata {
+  return createEventWithMetadata({
+    kind: MAP_NOTE_REPOST_KIND,
+    ...overrides,
+  });
+}
+
+export function createProfileEvent({
+  username = "alice",
+  pubkey = TEST_PUBKEY,
+}: {
+  username?: string;
+  pubkey?: string;
+} = {}): EventWithMetadata {
+  return createEventWithMetadata({
+    id: hex("c", 64),
+    pubkey,
+    kind: TRUSTROOTS_PROFILE_KIND,
+    content: JSON.stringify({ name: username }),
+    tags: [
+      ["L", "org.trustroots:username"],
+      ["l", username, "org.trustroots:username"],
+    ],
+  });
+}

--- a/nr-app/src/test/test-utils.tsx
+++ b/nr-app/src/test/test-utils.tsx
@@ -1,0 +1,99 @@
+import { combineSlices, configureStore } from "@reduxjs/toolkit";
+import { render, RenderOptions } from "@testing-library/react-native";
+import React, { PropsWithChildren, ReactElement } from "react";
+import { Provider } from "react-redux";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+
+import { eventsSlice } from "@/redux/slices/events.slice";
+import { keystoreSlice } from "@/redux/slices/keystore.slice";
+import { mapSlice } from "@/redux/slices/map.slice";
+import { metricsSlice } from "@/redux/slices/metrics.slice";
+import { notificationsSlice } from "@/redux/slices/notifications.slice";
+import { profilesSlice } from "@/redux/slices/profiles.slice";
+import { relaysSlice } from "@/redux/slices/relays.slice";
+import { settingsSlice } from "@/redux/slices/settings.slice";
+
+const testRootReducer = combineSlices(
+  eventsSlice,
+  keystoreSlice,
+  mapSlice,
+  metricsSlice,
+  notificationsSlice,
+  profilesSlice,
+  relaysSlice,
+  settingsSlice,
+);
+
+export type TestRootState = ReturnType<typeof testRootReducer>;
+export type TestStore = ReturnType<typeof createTestStore>;
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends Record<string, unknown>
+    ? DeepPartial<T[K]>
+    : T[K];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mergeState<T>(base: T, overrides: DeepPartial<T>): T {
+  if (!isRecord(base) || !isRecord(overrides)) {
+    return (overrides ?? base) as T;
+  }
+
+  const output: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(overrides)) {
+    const baseValue = output[key];
+    output[key] =
+      isRecord(baseValue) && isRecord(value)
+        ? mergeState(baseValue, value)
+        : value;
+  }
+  return output as T;
+}
+
+export function createTestStore(
+  preloadedState: DeepPartial<TestRootState> = {},
+) {
+  const initialState = testRootReducer(undefined, { type: "@@test/init" });
+
+  return configureStore({
+    reducer: testRootReducer,
+    preloadedState: mergeState(initialState, preloadedState),
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+        immutableCheck: false,
+      }),
+  });
+}
+
+export function renderWithProviders(
+  ui: ReactElement,
+  {
+    preloadedState,
+    store = createTestStore(preloadedState),
+    ...renderOptions
+  }: RenderOptions & {
+    preloadedState?: DeepPartial<TestRootState>;
+    store?: TestStore;
+  } = {},
+) {
+  function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <Provider store={store}>
+        <SafeAreaProvider
+          initialMetrics={{
+            frame: { x: 0, y: 0, width: 390, height: 844 },
+            insets: { top: 47, right: 0, bottom: 34, left: 0 },
+          }}
+        >
+          {children}
+        </SafeAreaProvider>
+      </Provider>
+    );
+  }
+
+  return { store, ...render(ui, { wrapper: Wrapper, ...renderOptions }) };
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "app:start": "pnpm --filter nr-app start",
     "postinstall": "patch-package",
     "test": "pnpm test:app && pnpm test:common",
+    "test:app:coverage": "pnpm --filter nr-app exec jest --watchman=false --coverage",
     "test:watch": "pnpm --filter nr-app test",
     "test:app": "pnpm --filter nr-app test",
     "test:common": "cd nr-common && deno task test"


### PR DESCRIPTION
## Summary

Broaden `nr-app` coverage beyond the browser-specific tests by adding shared app test infrastructure and focused Jest coverage for high-value general app workflows.

## What Changed

- Added shared `renderWithProviders()` and a configurable real Redux store factory for screen/component tests.
- Added reusable fixtures for Nostr events, map notes, Trustroots profile events, plus codes, and relay data.
- Added workflow/component tests for app routing, welcome/onboarding states, map list tabs, notification subscribe/unsubscribe, and add-note publish validation.
- Added reducer/selector tests for events, keystore, notifications, and settings.
- Added coverage scripts and ignored generated coverage output.

## Validation

- `pnpm --filter nr-app exec jest --watchman=false` passed: 25 suites, 106 tests.
- `pnpm --filter nr-app exec jest --watchman=false --coverage` passed.
- `pnpm test:app:coverage` passed.
- Scoped lint for the new/changed files passed.
- Full `pnpm --filter nr-app lint` still reports pre-existing unrelated issues in current app files.
