### PR TITLE
fix(nr-app): make Trustroots NIP-05 lookup case-insensitive

### DIFF
--- a/nr-app/app/onboarding/link.tsx
+++ b/nr-app/app/onboarding/link.tsx
@@ -13,6 +13,10 @@ import {
   settingsActions,
   settingsSelectors,
 } from "@/redux/slices/settings.slice";
+import {
+  buildTrustrootsNip05Identifier,
+  validateTrustrootsUsername,
+} from "@/utils/trustrootsUsername.utils";
 import { createKind10390EventTemplate } from "@trustroots/nr-common";
 import * as Clipboard from "expo-clipboard";
 import {
@@ -87,16 +91,17 @@ export default function OnboardingLinkScreen() {
         return;
       }
 
-      const normalizedUsername = (
-        usernameOverride !== undefined ? usernameOverride : trustrootsUsername
-      ).trim();
+      const validation = validateTrustrootsUsername(
+        usernameOverride !== undefined ? usernameOverride : trustrootsUsername,
+      );
 
-      if (!normalizedUsername) {
-        setLinkError("Enter your Trustroots username to continue.");
+      if (!validation.success) {
+        setLinkError(validation.error);
         return;
       }
 
-      const identifier = `${normalizedUsername}@trustroots.org`;
+      const normalizedUsername = validation.username;
+      const identifier = buildTrustrootsNip05Identifier(normalizedUsername);
 
       setLinkStatus("verifying");
       setLinkError(null);

--- a/nr-app/src/utils/trustrootsUsername.utils.test.ts
+++ b/nr-app/src/utils/trustrootsUsername.utils.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildTrustrootsNip05Identifier,
   normalizeTrustrootsUsername,
   validateTrustrootsUsername,
 } from "./trustrootsUsername.utils";
@@ -7,6 +8,17 @@ describe("trustrootsUsername.utils", () => {
   describe("normalizeTrustrootsUsername()", () => {
     it("trims and lowercases username input", () => {
       expect(normalizeTrustrootsUsername("  Alice  ")).toBe("alice");
+    });
+  });
+
+  describe("buildTrustrootsNip05Identifier()", () => {
+    it("builds a lowercased identifier regardless of input case", () => {
+      expect(buildTrustrootsNip05Identifier("Alice")).toBe(
+        "alice@trustroots.org",
+      );
+      expect(buildTrustrootsNip05Identifier("  MaRmAlAdEsKiEs ")).toBe(
+        "marmaladeskies@trustroots.org",
+      );
     });
   });
 

--- a/nr-app/src/utils/trustrootsUsername.utils.ts
+++ b/nr-app/src/utils/trustrootsUsername.utils.ts
@@ -10,8 +10,18 @@ export type TrustrootsUsernameValidationResult =
       error: string;
     };
 
+export const TRUSTROOTS_NIP05_DOMAIN = "trustroots.org";
+
 export function normalizeTrustrootsUsername(input: string): string {
   return input.trim().toLowerCase();
+}
+
+/**
+ * NIP-05 identifiers are matched case-insensitively, but Trustroots serves its
+ * nostr.json keyed on the lowercase username, so the lookup must be lowercased.
+ */
+export function buildTrustrootsNip05Identifier(input: string): string {
+  return `${normalizeTrustrootsUsername(input)}@${TRUSTROOTS_NIP05_DOMAIN}`;
 }
 
 export function validateTrustrootsUsername(


### PR DESCRIPTION
Closes #235

The manual link flow built the NIP-05 identifier straight from the raw text input with only a `.trim()`, so a username typed as `Alice` queried `Alice@trustroots.org` — but Trustroots keys its `nostr.json` response by the lowercase username (even after the server-side hardening, the `?name=` query is case-insensitive while the response stays lowercase-keyed), and `nostr-tools` reads `names[<exact queried name>]`, so any mixed-case input failed verification. Worse, the same raw value was published in the kind 10390 username tag and stored in settings, and nr-server re-verifies the tag's username case-sensitively, so a mixed-case username that somehow passed in-app would still fail server-side later. This PR routes the input through the existing `validateTrustrootsUsername` helper (which lowercases and trims but was never called here) and adds `buildTrustrootsNip05Identifier` so the lookup, the published tag, and settings all use the same normalized value; covered by new tests for `buildTrustrootsNip05Identifier` (`pnpm test` in `nr-app`: 86 passing).
