### PR TITLE
feat(nr-app): accept @username and trustroots.org addresses at setup

### DIFF
--- a/nr-app/app/onboarding/link.tsx
+++ b/nr-app/app/onboarding/link.tsx
@@ -247,6 +247,7 @@ export default function OnboardingLinkScreen() {
               setLinkStatus("idle");
             }}
             placeholder="Enter your Trustroots username"
+            autoComplete="username"
             className="w-full bg-muted text-foreground rounded-md p-3 text-sm mb-2 text-left"
           />
           <Button

--- a/nr-app/app/onboarding/trustroots.tsx
+++ b/nr-app/app/onboarding/trustroots.tsx
@@ -172,7 +172,8 @@ export default function OnboardingTrustrootsScreen() {
 
   const handleAuthenticateCode = useCallback(async () => {
     const username =
-      pendingTrustrootsUsername ?? usernameInput.trim().toLowerCase();
+      pendingTrustrootsUsername ??
+      validateTrustrootsUsername(usernameInput).username;
 
     if (!username || code.length !== 6) {
       return;
@@ -290,6 +291,9 @@ export default function OnboardingTrustrootsScreen() {
               placeholderTextColor="#6b7280"
               className="w-full bg-muted text-foreground rounded-md p-3 text-sm text-left"
             />
+            <Text className="text-xs text-muted-foreground text-left">
+              You can also enter @your-username or your-username@trustroots.org.
+            </Text>
             {fieldError && (
               <Text className="text-xs text-red-500 text-left">
                 {fieldError}

--- a/nr-app/src/utils/trustrootsUsername.utils.test.ts
+++ b/nr-app/src/utils/trustrootsUsername.utils.test.ts
@@ -39,11 +39,44 @@ describe("trustrootsUsername.utils", () => {
       });
     });
 
-    it("rejects email addresses", () => {
+    it("accepts an @-prefixed username", () => {
+      expect(validateTrustrootsUsername(" @Alice ")).toEqual({
+        success: true,
+        username: "alice",
+        error: null,
+      });
+    });
+
+    it("accepts a trustroots.org address and strips the domain", () => {
+      expect(validateTrustrootsUsername("Alice@Trustroots.org")).toEqual({
+        success: true,
+        username: "alice",
+        error: null,
+      });
+    });
+
+    it("rejects a non-Trustroots email address, which we cannot map to a username", () => {
       expect(validateTrustrootsUsername("alice@example.com")).toEqual({
         success: false,
         username: null,
-        error: "Enter your Trustroots username, not your email address.",
+        error:
+          "That looks like an email address. Enter your Trustroots username instead — you can find it on your Trustroots profile.",
+      });
+    });
+
+    it("rejects an address with more than one @", () => {
+      expect(validateTrustrootsUsername("a@b@trustroots.org")).toEqual({
+        success: false,
+        username: null,
+        error: "Enter only your Trustroots username.",
+      });
+    });
+
+    it("rejects a bare @ with no username", () => {
+      expect(validateTrustrootsUsername("@")).toEqual({
+        success: false,
+        username: null,
+        error: "Enter your Trustroots username.",
       });
     });
 

--- a/nr-app/src/utils/trustrootsUsername.utils.test.ts
+++ b/nr-app/src/utils/trustrootsUsername.utils.test.ts
@@ -55,12 +55,12 @@ describe("trustrootsUsername.utils", () => {
       });
     });
 
-    it("rejects a non-Trustroots email address, which we cannot map to a username", () => {
+    it("rejects a non-Trustroots email address, which we decline to look up", () => {
       expect(validateTrustrootsUsername("alice@example.com")).toEqual({
         success: false,
         username: null,
         error:
-          "That looks like an email address. Enter your Trustroots username instead — you can find it on your Trustroots profile.",
+          "That looks like an email address. We avoid email lookups for security reasons — please use your Trustroots username.",
       });
     });
 

--- a/nr-app/src/utils/trustrootsUsername.utils.ts
+++ b/nr-app/src/utils/trustrootsUsername.utils.ts
@@ -27,9 +27,13 @@ export function buildTrustrootsNip05Identifier(input: string): string {
 /**
  * Users reach for whatever identifier they have to hand, so accept the three
  * shapes that can be resolved to a username without a lookup: `alice`,
- * `@alice` and `alice@trustroots.org`. An arbitrary email cannot be mapped to
- * a username without an email->username endpoint Trustroots does not expose,
- * so it is reported rather than guessed at.
+ * `@alice` and `alice@trustroots.org`.
+ *
+ * An arbitrary email is rejected rather than looked up. nr-bridge could match
+ * one against the Trustroots `users` collection, but usernames are already
+ * public while emails are not, so an email-keyed lookup would turn
+ * `request_token` into an oracle for whether a given person has a Trustroots
+ * account at all.
  */
 function extractUsername(
   normalized: string,
@@ -56,7 +60,7 @@ function extractUsername(
         success: false,
         username: null,
         error:
-          "That looks like an email address. Enter your Trustroots username instead — you can find it on your Trustroots profile.",
+          "That looks like an email address. We avoid email lookups for security reasons — please use your Trustroots username.",
       };
     }
 

--- a/nr-app/src/utils/trustrootsUsername.utils.ts
+++ b/nr-app/src/utils/trustrootsUsername.utils.ts
@@ -24,12 +24,54 @@ export function buildTrustrootsNip05Identifier(input: string): string {
   return `${normalizeTrustrootsUsername(input)}@${TRUSTROOTS_NIP05_DOMAIN}`;
 }
 
+/**
+ * Users reach for whatever identifier they have to hand, so accept the three
+ * shapes that can be resolved to a username without a lookup: `alice`,
+ * `@alice` and `alice@trustroots.org`. An arbitrary email cannot be mapped to
+ * a username without an email->username endpoint Trustroots does not expose,
+ * so it is reported rather than guessed at.
+ */
+function extractUsername(
+  normalized: string,
+): TrustrootsUsernameValidationResult {
+  const withoutHandlePrefix = normalized.startsWith("@")
+    ? normalized.slice(1)
+    : normalized;
+
+  const atCount = (withoutHandlePrefix.match(/@/g) ?? []).length;
+
+  if (atCount > 1) {
+    return {
+      success: false,
+      username: null,
+      error: "Enter only your Trustroots username.",
+    };
+  }
+
+  if (atCount === 1) {
+    const [localPart, domain] = withoutHandlePrefix.split("@");
+
+    if (domain !== TRUSTROOTS_NIP05_DOMAIN) {
+      return {
+        success: false,
+        username: null,
+        error:
+          "That looks like an email address. Enter your Trustroots username instead — you can find it on your Trustroots profile.",
+      };
+    }
+
+    return { success: true, username: localPart, error: null };
+  }
+
+  return { success: true, username: withoutHandlePrefix, error: null };
+}
+
 export function validateTrustrootsUsername(
   input: string,
 ): TrustrootsUsernameValidationResult {
-  const username = normalizeTrustrootsUsername(input);
+  const normalized = normalizeTrustrootsUsername(input);
 
-  if (!username) {
+  if (!normalized) {
     return {
       success: false,
       username: null,
@@ -37,11 +79,19 @@ export function validateTrustrootsUsername(
     };
   }
 
-  if (username.includes("@")) {
+  const extracted = extractUsername(normalized);
+
+  if (!extracted.success) {
+    return extracted;
+  }
+
+  const username = extracted.username;
+
+  if (!username) {
     return {
       success: false,
       username: null,
-      error: "Enter your Trustroots username, not your email address.",
+      error: "Enter your Trustroots username.",
     };
   }
 


### PR DESCRIPTION
Refs #208

> ⚠️ **Stacked on #250** (`fix/235-nip05-case-insensitive`). Base is that branch, not `main` — merge #250 first and this will retarget cleanly.

## What this does

The setup field asked for a "Trustroots Account" without saying what that meant, and accepted only a bare username. It now takes the three shapes that can be resolved to a username **without a lookup**:

| Input | Result |
|---|---|
| `alice` | `alice` |
| `@Alice` | `alice` |
| `Alice@Trustroots.org` | `alice` |

Also adds a hint line under the input so the accepted formats are discoverable rather than trial-and-error, and routes the code-entry fallback in `onboarding/trustroots.tsx` through the same validator (it was doing a raw `.trim().toLowerCase()`, so `@alice` would have been sent un-stripped).

## What this deliberately does NOT do

The issue asks for **email** to work too. An arbitrary email (`alice@gmail.com`) cannot be resolved to a username: Trustroots NIP-05 is keyed on username, and there is no public email→username endpoint. Adding one would be a **user-enumeration surface** — anyone could test whether an email has a Trustroots account.

That input now gets a clear error pointing at the username instead of failing mysteriously. If we do want email to work, it needs a Trustroots API change and is worth discussing as one — so I've left #208 open rather than closing it.

## Tests

`pnpm test` in `nr-app`: 90 passing. Covers all three accepted shapes plus the rejected ones (foreign-domain email, multiple `@`, bare `@`).