### PR TITLE
feat: raise note content limit from 300 to 4000 characters

### DIFF
--- a/nr-app/src/components/AddNoteForm.tsx
+++ b/nr-app/src/components/AddNoteForm.tsx
@@ -7,7 +7,10 @@ import {
   SignalDuration,
   SignalIntent,
 } from "@/constants/signals";
-import { getCurrentTimestamp } from "@trustroots/nr-common";
+import {
+  CONTENT_MAXIMUM_LENGTH,
+  getCurrentTimestamp,
+} from "@trustroots/nr-common";
 import { nanoid } from "@reduxjs/toolkit";
 import { CalendarDays, Send } from "lucide-react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
@@ -264,8 +267,14 @@ export default function AddNoteForm({
             onChangeText={setNoteContent}
             onSubmitEditing={handleSend}
             multiline={true}
+            maxLength={CONTENT_MAXIMUM_LENGTH}
             style={{ maxHeight: 100 }}
           />
+          {noteContent.length > CONTENT_MAXIMUM_LENGTH - 200 && (
+            <Text className="text-[11px] text-muted-foreground text-right mt-1">
+              {CONTENT_MAXIMUM_LENGTH - noteContent.length} characters left
+            </Text>
+          )}
         </View>
         <Button
           onPress={handleSend}

--- a/nr-common/constants.ts
+++ b/nr-common/constants.ts
@@ -58,7 +58,14 @@ export const TRUSTROOTS_PICTURE_LABEL_NAMESPACE = "org.trustroots:picture";
 export const TRUSTROOTS_USERNAME_MIN_LENGTH = 3;
 
 export const CONTENT_MINIMUM_LENGTH = 3;
-export const CONTENT_MAXIMUM_LENGTH = 300;
+/**
+ * Neither NIP-01 nor the relay's NIP-11 document defines a content limit
+ * (relay.trustroots.org advertises no max_content_length; its only ceiling is
+ * max_message_length, 131072 bytes for the whole JSON message). The old 300
+ * was ours alone and truncated legitimate notes. This bound exists purely to
+ * keep an upper limit on what nr-server will accept and repost.
+ */
+export const CONTENT_MAXIMUM_LENGTH = 4000;
 
 export const AMQP_EXCHANGE_NAME = "nostrEvents" as const;
 export const AMQP_EXCHANGE_TYPE = "fanout" as const;

--- a/nr-common/src/base.schema.test.ts
+++ b/nr-common/src/base.schema.test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { CONTENT_MAXIMUM_LENGTH, CONTENT_MINIMUM_LENGTH } from "../constants.ts";
+import { contentSchema } from "./base.schema.ts";
+
+Deno.test("contentSchema accepts content well beyond the old 300 char limit", () => {
+  assertEquals(contentSchema.safeParse("a".repeat(1000)).success, true);
+});
+
+Deno.test("contentSchema accepts content at the maximum length", () => {
+  assertEquals(
+    contentSchema.safeParse("a".repeat(CONTENT_MAXIMUM_LENGTH)).success,
+    true,
+  );
+});
+
+Deno.test("contentSchema still rejects content above the maximum length", () => {
+  assertEquals(
+    contentSchema.safeParse("a".repeat(CONTENT_MAXIMUM_LENGTH + 1)).success,
+    false,
+  );
+});
+
+Deno.test("contentSchema still rejects content below the minimum length", () => {
+  assertEquals(
+    contentSchema.safeParse("a".repeat(CONTENT_MINIMUM_LENGTH - 1)).success,
+    false,
+  );
+});


### PR DESCRIPTION
Closes #249

## ⚠️ Deploy order matters — read before merging

`CONTENT_MAXIMUM_LENGTH` lives in `nr-common/constants.ts` and is enforced by `contentSchema`, which **nr-server also uses** to decide whether to repost a kind 30397 as a verified kind 30398.

If clients ship this before nr-server is redeployed, a long note will validate happily in the app, publish to the relay, and then be **silently dropped server-side** — never reposted, so it never appears on the Trustroots layer. The user watches their note vanish with no error.

**Deploy nr-server first, then the clients.**

## Why 4000, and why a limit at all

There is no protocol limit to honour here — I checked:

- **NIP-01** defines no maximum content length.
- **`relay.trustroots.org`'s own NIP-11 document advertises no `max_content_length`.** Its only ceiling is `max_message_length` = 131072 bytes, for the entire JSON message.

So the 300 was a Nostroots invention, not a protocol constraint, and it was truncating legitimate notes (see the squat/bridge listing in the issue).

I kept *a* bound rather than removing it outright, purely so nr-server retains an upper limit on what it will accept and repost — an unbounded content field on the relay is an abuse vector. 4000 is ~2% of the relay's real ceiling and generous for the use case in the issue.

**Removing the bound entirely is also defensible** — that's literally what the issue title asks for. I didn't do it unilaterally because it's a judgement call about relay abuse. Happy to change it.

## Also

`AddNoteForm` had no `maxLength` and no counter, so exceeding the cap failed silently at publish time. It now caps the input and shows a remaining-character count as you approach the limit.

## Tests

- `nr-common`: `deno task test` — 9 passing, 4 new (content at/above/below the bound, and well past the old 300).
- `nr-app`: `pnpm test` — 85 passing.