### PR TITLE
feat(nr-app): add a button to send debug info to support

### DIFF
--- a/nr-app/app/(main)/(views)/settings.tsx
+++ b/nr-app/app/(main)/(views)/settings.tsx
@@ -7,6 +7,7 @@ import { ScrollView, Switch, TextInput, View } from "react-native";
 
 import { BrowserSettingsSection } from "@/browser/BrowserSettingsSection";
 import BuildData from "@/components/BuildData";
+import { SendDebugInfoButton } from "@/components/SendDebugInfoButton";
 import { KeyInput } from "@/components/KeyInput";
 import { Button } from "@/components/ui/button";
 import { Section } from "@/components/ui/section";
@@ -354,6 +355,15 @@ export default function SettingsScreen() {
             disabled={isImporting || importStatus === "saved"}
           />
         </View>
+      </Section>
+
+      <Section>
+        <Text className="font-bold">Support</Text>
+        <Text className="text-sm text-muted-foreground">
+          Having trouble? Copy your app&apos;s debug info and paste it into the
+          support form so we can help.
+        </Text>
+        <SendDebugInfoButton />
       </Section>
 
       {areTestFeaturesEnabled ? (

--- a/nr-app/src/components/SendDebugInfoButton.tsx
+++ b/nr-app/src/components/SendDebugInfoButton.tsx
@@ -1,0 +1,66 @@
+import Constants from "expo-constants";
+import * as Clipboard from "expo-clipboard";
+import * as Updates from "expo-updates";
+import * as WebBrowser from "expo-web-browser";
+import { LifeBuoy } from "lucide-react-native";
+import { useCallback } from "react";
+import { Alert, Platform } from "react-native";
+
+import { useAppSelector } from "@/redux/hooks";
+import { keystoreSelectors } from "@/redux/slices/keystore.slice";
+import { settingsSelectors } from "@/redux/slices/settings.slice";
+import {
+  formatDebugInfo,
+  TRUSTROOTS_SUPPORT_URL,
+} from "@/utils/debugInfo.utils";
+import { Button } from "./ui/button";
+import { Icon } from "./ui/icon";
+import { Text } from "./ui/text";
+
+export function SendDebugInfoButton() {
+  const npub = useAppSelector(keystoreSelectors.selectPublicKeyNpub);
+  const trustrootsUsername = useAppSelector(settingsSelectors.selectUsername);
+
+  const handlePress = useCallback(async () => {
+    const debugInfo = formatDebugInfo({
+      appVersion: Constants.expoConfig?.version,
+      buildNumber:
+        Platform.OS === "ios"
+          ? Constants.expoConfig?.ios?.buildNumber
+          : Constants.expoConfig?.android?.versionCode,
+      commitId: Constants.expoConfig?.extra?.commitId,
+      platform: Platform.OS,
+      platformVersion: Platform.Version,
+      updateChannel: Updates.channel ?? undefined,
+      updateId: Updates.updateId ?? undefined,
+      updateCreatedAt: Updates.createdAt,
+      isEmbeddedLaunch: Updates.isEmbeddedLaunch,
+      npub: npub ?? undefined,
+      trustrootsUsername: trustrootsUsername ?? undefined,
+      generatedAt: new Date(),
+    });
+
+    await Clipboard.setStringAsync(debugInfo);
+
+    Alert.alert(
+      "Debug info copied",
+      "We copied your app's debug info to the clipboard. Paste it into the support form so we can see what went wrong.\n\nIt includes your app version and your npub and Trustroots username if you have set them.",
+      [
+        { text: "Not now", style: "cancel" },
+        {
+          text: "Open support",
+          onPress: () => {
+            WebBrowser.openBrowserAsync(TRUSTROOTS_SUPPORT_URL);
+          },
+        },
+      ],
+    );
+  }, [npub, trustrootsUsername]);
+
+  return (
+    <Button onPress={handlePress} variant="outline" className="w-full">
+      <Icon as={LifeBuoy} size={16} className="text-foreground" />
+      <Text>Send debug info to support</Text>
+    </Button>
+  );
+}

--- a/nr-app/src/utils/debugInfo.utils.test.ts
+++ b/nr-app/src/utils/debugInfo.utils.test.ts
@@ -1,0 +1,62 @@
+import { DebugInfo, formatDebugInfo } from "./debugInfo.utils";
+
+const baseInfo: DebugInfo = {
+  appVersion: "0.0.4",
+  buildNumber: 27,
+  commitId: "abc1234",
+  platform: "android",
+  platformVersion: 34,
+  isEmbeddedLaunch: true,
+  generatedAt: new Date(2026, 6, 13, 9, 5),
+};
+
+describe("formatDebugInfo()", () => {
+  it("includes version, build, platform and generation date", () => {
+    const output = formatDebugInfo(baseInfo);
+
+    expect(output).toContain("Generated: 2026-07-13 09:05");
+    expect(output).toContain("App version: 0.0.4");
+    expect(output).toContain("Build: 27");
+    expect(output).toContain("Commit: abc1234");
+    expect(output).toContain("Platform: android 34");
+  });
+
+  it("reports an embedded launch instead of OTA fields", () => {
+    const output = formatDebugInfo(baseInfo);
+
+    expect(output).toContain("Update: embedded build (no OTA update applied)");
+    expect(output).not.toContain("Update channel:");
+  });
+
+  it("reports OTA update details when running an update", () => {
+    const output = formatDebugInfo({
+      ...baseInfo,
+      isEmbeddedLaunch: false,
+      updateChannel: "preview",
+      updateId: "uuid-1",
+      updateCreatedAt: new Date(2026, 6, 12, 18, 30),
+    });
+
+    expect(output).toContain("Update channel: preview");
+    expect(output).toContain("Update ID: uuid-1");
+    expect(output).toContain("Update published: 2026-07-12 18:30");
+  });
+
+  it("marks an unset identity explicitly rather than omitting it", () => {
+    const output = formatDebugInfo(baseInfo);
+
+    expect(output).toContain("npub: not set");
+    expect(output).toContain("Trustroots username: not set");
+  });
+
+  it("includes identity when set", () => {
+    const output = formatDebugInfo({
+      ...baseInfo,
+      npub: "npub1abc",
+      trustrootsUsername: "marmaladeskies",
+    });
+
+    expect(output).toContain("npub: npub1abc");
+    expect(output).toContain("Trustroots username: marmaladeskies");
+  });
+});

--- a/nr-app/src/utils/debugInfo.utils.ts
+++ b/nr-app/src/utils/debugInfo.utils.ts
@@ -1,0 +1,58 @@
+export const TRUSTROOTS_SUPPORT_URL = "https://www.trustroots.org/support";
+
+export interface DebugInfo {
+  appVersion?: string;
+  buildNumber?: string | number;
+  commitId?: string;
+  platform: string;
+  platformVersion: string | number;
+  updateChannel?: string;
+  updateId?: string;
+  updateCreatedAt?: Date | null;
+  isEmbeddedLaunch: boolean;
+  npub?: string;
+  trustrootsUsername?: string;
+  generatedAt: Date;
+}
+
+function formatTimestamp(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ` +
+    `${pad(date.getHours())}:${pad(date.getMinutes())}`
+  );
+}
+
+/**
+ * Support pastes this into a ticket, so it is plain text rather than JSON and
+ * every field is always present -- "not set" is itself diagnostic.
+ */
+export function formatDebugInfo(info: DebugInfo): string {
+  const lines = [
+    "Nostroots debug info",
+    `Generated: ${formatTimestamp(info.generatedAt)}`,
+    "",
+    `App version: ${info.appVersion ?? "unknown"}`,
+    `Build: ${info.buildNumber ?? "unknown"}`,
+    `Commit: ${info.commitId ?? "unknown"}`,
+    `Platform: ${info.platform} ${info.platformVersion}`,
+    "",
+    info.isEmbeddedLaunch
+      ? "Update: embedded build (no OTA update applied)"
+      : [
+          `Update channel: ${info.updateChannel ?? "unknown"}`,
+          `Update ID: ${info.updateId ?? "unknown"}`,
+          `Update published: ${
+            info.updateCreatedAt
+              ? formatTimestamp(info.updateCreatedAt)
+              : "unknown"
+          }`,
+        ].join("\n"),
+    "",
+    `npub: ${info.npub ?? "not set"}`,
+    `Trustroots username: ${info.trustrootsUsername ?? "not set"}`,
+  ];
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
Closes #247

## What

Adds a **Send debug info to support** button in Settings. It copies a plain-text diagnostic block to the clipboard, explains what was copied, and offers to open the Trustroots support form.

Covers everything the issue asked for:

```
Nostroots debug info
Generated: 2026-07-13 09:05

App version: 0.0.4
Build: 27
Commit: abc1234
Platform: android 34

Update channel: preview
Update ID: uuid-1
Update published: 2026-07-12 18:30

npub: npub1abc
Trustroots username: marmaladeskies
```

(Or `Update: embedded build (no OTA update applied)` when not running an OTA update.)

## Two deliberate choices

**It is NOT behind the dev-features toggle.** `BuildData` — which already gathered most of this — sits behind `areTestFeaturesEnabled`, which makes it useless for the people who need it. The users who need to send debug info are precisely the ones who cannot get the app working in the first place.

**Unset fields say `not set` rather than being omitted.** "This user has no npub" is itself diagnostic information for whoever picks up the ticket.

Formatting follows the repo's `yyyy-mm-dd hh:mm` convention from AGENTS.md.

## Tests

`pnpm test` in `nr-app`: 90 passing. The formatter is a pure function with 5 new tests; the component is a thin wrapper around it.