### PR TITLE
fix(nr-app): make key fields readable in dark mode

### DIFF
--- a/nr-app/app/(main)/(views)/settings.tsx
+++ b/nr-app/app/(main)/(views)/settings.tsx
@@ -206,7 +206,8 @@ export default function SettingsScreen() {
     }
   };
 
-  const inputClassName = "border border-border rounded px-3 py-2 bg-background";
+  const inputClassName =
+    "border border-border rounded px-3 py-2 bg-background text-foreground";
 
   const hasUsernameOrHasTestFeaturesEnabled =
     (typeof username === "string" && username.length > 0) ||

--- a/nr-app/src/components/KeyInput.tsx
+++ b/nr-app/src/components/KeyInput.tsx
@@ -90,7 +90,8 @@ export function KeyInput({
           value={value}
           onChangeText={onChangeText}
           placeholder={placeholder}
-          className="border border-border rounded-lg p-3 pr-12 text-sm bg-background"
+          placeholderTextColor="#6b7280"
+          className="border border-border rounded-lg p-3 pr-12 text-sm bg-background text-foreground"
           editable={!disabled}
         />
         <Pressable


### PR DESCRIPTION
Refs #241

## The bug

The issue reports that "the nsec/npub fields aren't readable" in dark mode. That's a real, specific bug with a one-line cause.

The nsec, npub, public key hex, mnemonic and relay inputs set `bg-background` but **never set a text colour**. `.dark:root` flips `--background` to 3.9% lightness (near-black) but the inputs kept rendering text in the default near-black — so it was black-on-black and invisible.

Adding `text-foreground` makes the text track the theme token, which `.dark:root` flips to 98%. Fixed in `settings.tsx` (one shared `inputClassName` covers npub / pubkey hex / nsec / mnemonic / relays) and in `KeyInput.tsx`.

## What I did NOT do

The issue also proposes **dropping dark mode for a while**. I didn't, for two reasons:

1. There is now an explicit Appearance toggle (System / Light / Dark) in Settings that postdates the issue.
2. Ripping out dark mode is a product decision, not a bug fix.

So this closes the concrete complaint but leaves #241 open for that call. If the team does want dark mode gone, that's a separate PR.

I've left the issue open rather than auto-closing it.

## Tests

`pnpm test` in `nr-app`: 85 passing (no behavioural change; this is a styling fix).