### PR TITLE
refactor(nr-app): sync Trustroots setup state during render, not in effects

### DIFF
--- a/nr-app/app/onboarding/trustroots.tsx
+++ b/nr-app/app/onboarding/trustroots.tsx
@@ -1,7 +1,7 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
 import { AlertTriangleIcon, MailCheckIcon } from "lucide-react-native";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import { TextInput, View } from "react-native";
 
 import { Button } from "@/components/ui/button";
@@ -29,6 +29,16 @@ type TrustrootsScreenState =
   | "profile-publishing";
 
 const AUTHENTICATION_FAILURE_MESSAGE = "failed to authenticate you. try again";
+
+const ERROR_PARAM_MESSAGES: Record<string, string> = {
+  auth: AUTHENTICATION_FAILURE_MESSAGE,
+  "missing-token": "Verification link is missing a token. Try again.",
+  "start-in-app":
+    "Start verification in the app before opening the email link.",
+};
+
+/** Distinguishes "not synced yet" from a genuinely absent value. */
+const UNSYNCED = Symbol("unsynced");
 
 function getRequestErrorMessage(error: unknown): string {
   if (error instanceof NrBridgeError) {
@@ -61,38 +71,41 @@ export default function OnboardingTrustrootsScreen() {
   const [fieldError, setFieldError] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (errorParam === "auth") {
-      setStatusMessage(AUTHENTICATION_FAILURE_MESSAGE);
-    } else if (errorParam === "missing-token") {
-      setStatusMessage("Verification link is missing a token. Try again.");
-    } else if (errorParam === "start-in-app") {
-      setStatusMessage(
-        "Start verification in the app before opening the email link.",
-      );
-    }
-  }, [errorParam]);
+  const [syncedErrorParam, setSyncedErrorParam] = useState<
+    string | undefined | typeof UNSYNCED
+  >(UNSYNCED);
+  const [syncedProfileUsername, setSyncedProfileUsername] = useState<
+    string | null | typeof UNSYNCED
+  >(UNSYNCED);
+  const [syncedPendingUsername, setSyncedPendingUsername] = useState<
+    string | null | typeof UNSYNCED
+  >(UNSYNCED);
 
-  useEffect(() => {
+  if (syncedErrorParam !== errorParam) {
+    setSyncedErrorParam(errorParam);
+    const message = errorParam ? ERROR_PARAM_MESSAGES[errorParam] : undefined;
+    if (message) {
+      setStatusMessage(message);
+    }
+  }
+
+  if (syncedProfileUsername !== pendingTrustrootsProfileUsername) {
+    setSyncedProfileUsername(pendingTrustrootsProfileUsername);
     if (pendingTrustrootsProfileUsername) {
       setUsernameInput(pendingTrustrootsProfileUsername);
       setScreenState("profile-retry");
       setStatusMessage(
         "Your Trustroots account was authenticated. Retry the profile publish to finish setup.",
       );
-      return;
     }
-
+  } else if (syncedPendingUsername !== pendingTrustrootsUsername) {
+    setSyncedPendingUsername(pendingTrustrootsUsername);
     if (pendingTrustrootsUsername && screenState === "idle") {
       setUsernameInput(pendingTrustrootsUsername);
       setScreenState("code-entry");
       setStatusMessage("Enter the six-digit code from your email.");
     }
-  }, [
-    pendingTrustrootsProfileUsername,
-    pendingTrustrootsUsername,
-    screenState,
-  ]);
+  }
 
   const resetToUsernameEntry = useCallback(
     (message?: string) => {


### PR DESCRIPTION
Split out of #256, where this started as a drive-by needed to get past the pre-commit lint. It stands alone, so it should be reviewed alone.

## The lint error

`onboarding/trustroots.tsx` has two `useEffect` blocks that mirror external values — the `error` route param, and the two pending-username values from redux — into local state. Both trip `react-hooks/set-state-in-effect`, so the pre-commit hook rejects *any* commit touching this file.

## The fix

Replace them with React's documented [adjust-state-on-change](https://react.dev/reference/react/useState#storing-information-from-previous-renders) pattern: hold the last-synced value in state, compare it against the external one during render, and update only on a change. A `UNSYNCED` symbol distinguishes "never synced" from a genuinely absent value, so the first render still applies the param/redux state the effects used to apply on mount.

## It also fixes a real bug

The second effect listed `screenState` in its dependency array. So when `runProfileFinalization` set `profile-publishing`, the effect re-ran, saw `pendingTrustrootsProfileUsername` still set, and pushed the screen straight back to `profile-retry` — mid-publish, with a "retry the profile publish" message, while the publish was still in flight.

The render-phase version only fires when the redux value itself changes, so the publishing state survives.

## Tests

`pnpm test` in `nr-app`: 94 passing; eslint clean on the file; `tsc` reports no errors in it.

⚠️ There is no component-level test for this screen — only for the username validator — so the two sync paths (arriving with `?error=auth`; arriving with a pending profile username) are covered by lint and review, not by an executed test. Happy to add a render test if you want that locked down before merge.