### PR TITLE
feat(nr-app): let users browse the map before creating a key

### DIFF
--- a/nr-app/app/(main)/(views)/settings.tsx
+++ b/nr-app/app/(main)/(views)/settings.tsx
@@ -152,8 +152,7 @@ export default function SettingsScreen() {
   ) as boolean;
 
   // Onboarding configuration flags.
-  const { useSkipOnboarding, forceOnboarding, forceWelcome } =
-    useAppSelector(selectFeatureFlags);
+  const { forceOnboarding, forceWelcome } = useAppSelector(selectFeatureFlags);
 
   const [nsec, setNsec] = useState("");
   const [mnemonic, setMnemonic] = useState("");
@@ -508,16 +507,6 @@ export default function SettingsScreen() {
       {areTestFeaturesEnabled && (
         <Section>
           <Text variant="h2">Onboarding / Welcome Flags</Text>
-
-          <ToggleSwitch
-            label="Allow skipping onboarding flow"
-            value={useSkipOnboarding}
-            onToggle={() => {
-              dispatch(
-                settingsActions.setUseSkipOnboarding(!useSkipOnboarding),
-              );
-            }}
-          />
 
           <ToggleSwitch
             label="Force onboarding on startup"

--- a/nr-app/app/index.tsx
+++ b/nr-app/app/index.tsx
@@ -1,10 +1,9 @@
-import { Redirect } from "expo-router";
+import { Href, Redirect } from "expo-router";
 import { useEffect, useState } from "react";
 
 import { nip19 } from "nostr-tools";
 
 import LoadingScreen from "@/components/LoadingModal";
-import { ROUTES } from "@/constants/routes";
 import { getPublicKeyHexFromSecureStorage } from "@/nostr/keystore.nostr";
 import { useAppDispatch, useAppSelector } from "@/redux/hooks";
 import {
@@ -16,6 +15,7 @@ import {
   settingsActions,
   settingsSelectors,
 } from "@/redux/slices/settings.slice";
+import { resolveStartupRoute } from "@/utils/startupRoute.utils";
 import { getNip5PubKey } from "@trustroots/nr-common";
 
 export default function IndexRoute() {
@@ -29,6 +29,9 @@ export default function IndexRoute() {
   const username = useAppSelector(settingsSelectors.selectUsername);
   const hasBeenOpenedBefore = useAppSelector(
     settingsSelectors.selectHasBeenOpenedBefore,
+  );
+  const isBrowsingAsGuest = useAppSelector(
+    settingsSelectors.selectIsBrowsingAsGuest,
   );
   const { forceOnboarding, forceWelcome } = useAppSelector(selectFeatureFlags);
 
@@ -102,21 +105,19 @@ export default function IndexRoute() {
     return <LoadingScreen loading={true} />;
   }
 
-  // Determine destination
-  const showWelcome = !hasBeenOpenedBefore || forceWelcome;
-  const showOnboarding = !username || !npub || nip5Error || forceOnboarding;
-
-  if (showWelcome) {
-    return <Redirect href={ROUTES.WELCOME} />;
-  }
-
-  if (showOnboarding) {
-    return (
-      <Redirect
-        href={nip5Error ? ROUTES.ONBOARDING_ERROR : ROUTES.ONBOARDING}
-      />
-    );
-  }
-
-  return <Redirect href={ROUTES.HOME} />;
+  return (
+    <Redirect
+      href={
+        resolveStartupRoute({
+          hasBeenOpenedBefore,
+          username,
+          npub,
+          nip5Error,
+          isBrowsingAsGuest,
+          forceOnboarding,
+          forceWelcome,
+        }) as Href
+      }
+    />
+  );
 }

--- a/nr-app/app/onboarding/identity.tsx
+++ b/nr-app/app/onboarding/identity.tsx
@@ -6,12 +6,12 @@ import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { ROUTES } from "@/constants/routes";
 import { IdCardLanyardIcon } from "lucide-react-native";
-import { selectFeatureFlags } from "@/redux/slices/settings.slice";
-import { useAppSelector } from "@/redux/hooks";
+import { settingsActions } from "@/redux/slices/settings.slice";
+import { useAppDispatch } from "@/redux/hooks";
 
 export default function OnboardingIdentityScreen() {
   const router = useRouter();
-  const { useSkipOnboarding } = useAppSelector(selectFeatureFlags);
+  const dispatch = useAppDispatch();
 
   const goBack = () => {
     router.back();
@@ -21,8 +21,9 @@ export default function OnboardingIdentityScreen() {
     router.push("/onboarding/trustroots");
   };
 
-  const goSkip = () => {
-    router.push(ROUTES.HOME);
+  const goBrowse = () => {
+    dispatch(settingsActions.setIsBrowsingAsGuest(true));
+    router.replace(ROUTES.HOME);
   };
 
   return (
@@ -58,15 +59,13 @@ export default function OnboardingIdentityScreen() {
           size="lg"
           title="Continue"
         />
-        {useSkipOnboarding && (
-          <Button
-            variant="outline"
-            onPress={goSkip}
-            size="lg"
-            title="Skip"
-            textClassName="text-white"
-          />
-        )}
+        <Button
+          variant="outline"
+          onPress={goBrowse}
+          size="lg"
+          title="Browse first"
+          textClassName="text-white"
+        />
       </View>
 
       <View className="p-4 opacity-75">

--- a/nr-app/src/components/MapModal.tsx
+++ b/nr-app/src/components/MapModal.tsx
@@ -3,6 +3,7 @@ import {
   BottomSheetModalProvider,
   BottomSheetScrollView,
 } from "@expo/ui/community/bottom-sheet";
+import { useRouter } from "expo-router";
 import { useColorScheme } from "nativewind";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Pressable, View, useWindowDimensions } from "react-native";
@@ -15,7 +16,9 @@ import { EventWithMetadata } from "@/redux/slices/events.slice";
 import { keystoreSelectors } from "@/redux/slices/keystore.slice";
 import { mapActions, mapSelectors } from "@/redux/slices/map.slice";
 import { RootState } from "@/redux/store";
+import { ROUTES } from "@/constants/routes";
 import AddNoteForm from "./AddNoteForm";
+import { Button } from "./ui/button";
 import NotesList, { getNotesSummaryText, useNotesListData } from "./NotesList";
 import PeopleStrip from "./PeopleStrip";
 import SubscribeBellIcon from "./SubscribeBellIcon";
@@ -24,6 +27,7 @@ import { Text } from "./ui/text";
 
 export default function MapModal() {
   const dispatch = useAppDispatch();
+  const router = useRouter();
   const { colorScheme } = useColorScheme();
   const { height } = useWindowDimensions();
   const { top } = useSafeAreaInsets();
@@ -72,6 +76,11 @@ export default function MapModal() {
   const handleClose = useCallback(() => {
     bottomSheetRef.current?.dismiss();
   }, []);
+
+  const handleSetUpAccount = useCallback(() => {
+    bottomSheetRef.current?.dismiss();
+    router.push(ROUTES.ONBOARDING);
+  }, [router]);
 
   const canPost =
     hasPrivateKeyInSecureStorage && selectedLayer === "trustroots";
@@ -139,10 +148,15 @@ export default function MapModal() {
         {/* Compose bar — pinned to bottom */}
         <View className="border-t border-border/15 bg-muted/10">
           {!hasPrivateKeyInSecureStorage ? (
-            <View className="px-5 py-3">
+            <View className="px-5 py-3 gap-2">
               <Text className="text-sm text-muted-foreground">
-                Set up your private key in settings to post.
+                Set up your Trustroots account to post here.
               </Text>
+              <Button
+                variant="secondary"
+                onPress={handleSetUpAccount}
+                title="Set up account"
+              />
             </View>
           ) : selectedLayer === "trustroots" ? (
             <AddNoteForm

--- a/nr-app/src/redux/slices/settings.slice.ts
+++ b/nr-app/src/redux/slices/settings.slice.ts
@@ -8,7 +8,7 @@ type SettingsState = {
   hasBeenOpenedBefore: boolean;
   isDataLoaded: boolean;
   areTestFeaturesEnabled: boolean;
-  useSkipOnboarding: boolean;
+  isBrowsingAsGuest: boolean;
   forceOnboarding: boolean;
   forceWelcome: boolean;
   colorScheme: ColorSchemePreference;
@@ -23,7 +23,7 @@ const initialState: SettingsState = {
   hasBeenOpenedBefore: false,
   isDataLoaded: false,
   areTestFeaturesEnabled: false,
-  useSkipOnboarding: true,
+  isBrowsingAsGuest: false,
   forceOnboarding: false,
   forceWelcome: false,
   colorScheme: "system",
@@ -42,6 +42,7 @@ export const settingsSlice = createSlice({
     },
     setUsername: (state, action: PayloadAction<string>) => {
       state.username = action.payload;
+      state.isBrowsingAsGuest = false;
     },
     setHasBeenOpenedBefore: (state, action: PayloadAction<boolean>) => {
       state.hasBeenOpenedBefore = action.payload;
@@ -49,8 +50,8 @@ export const settingsSlice = createSlice({
     setDataLoaded: (state, action: PayloadAction<boolean>) => {
       state.isDataLoaded = action.payload;
     },
-    setUseSkipOnboarding: (state, action: PayloadAction<boolean>) => {
-      state.useSkipOnboarding = action.payload;
+    setIsBrowsingAsGuest: (state, action: PayloadAction<boolean>) => {
+      state.isBrowsingAsGuest = action.payload;
     },
     setForceOnboarding: (state, action: PayloadAction<boolean>) => {
       state.forceOnboarding = action.payload;
@@ -94,6 +95,7 @@ export const settingsSlice = createSlice({
     selectUsername: (state) => state.username,
     selectHasBeenOpenedBefore: (state) => state.hasBeenOpenedBefore,
     selectIsDataLoaded: (state) => state.isDataLoaded,
+    selectIsBrowsingAsGuest: (state) => state.isBrowsingAsGuest,
     selectColorScheme: (state) => state.colorScheme,
     selectKeyWasImported: (state) => state.keyWasImported,
     selectHasAcknowledgedExperimentalLayers: (state) =>
@@ -111,7 +113,6 @@ export const settingsSelectors = settingsSlice.selectors;
 export const selectFeatureFlags = createSelector(
   (state: RootState) => state.settings,
   (settings: SettingsState) => ({
-    useSkipOnboarding: settings.useSkipOnboarding,
     forceOnboarding: settings.forceOnboarding,
     forceWelcome: settings.forceWelcome,
   }),

--- a/nr-app/src/utils/startupRoute.utils.test.ts
+++ b/nr-app/src/utils/startupRoute.utils.test.ts
@@ -1,0 +1,86 @@
+import { ROUTES } from "@/constants/routes";
+import { resolveStartupRoute } from "./startupRoute.utils";
+
+const onboardedUser = {
+  hasBeenOpenedBefore: true,
+  username: "alice",
+  npub: "npub1alice" as `npub${string}`,
+  nip5Error: false,
+  isBrowsingAsGuest: false,
+  forceOnboarding: false,
+  forceWelcome: false,
+};
+
+const freshUser = {
+  ...onboardedUser,
+  hasBeenOpenedBefore: false,
+  username: null,
+  npub: undefined,
+};
+
+describe("resolveStartupRoute", () => {
+  it("sends a first-time user to the welcome screen", () => {
+    expect(resolveStartupRoute(freshUser)).toBe(ROUTES.WELCOME);
+  });
+
+  it("sends a returning user with no key into onboarding", () => {
+    expect(
+      resolveStartupRoute({ ...freshUser, hasBeenOpenedBefore: true }),
+    ).toBe(ROUTES.ONBOARDING);
+  });
+
+  it("sends a fully onboarded user home", () => {
+    expect(resolveStartupRoute(onboardedUser)).toBe(ROUTES.HOME);
+  });
+
+  it("sends a user with a failing NIP-05 check to the error screen", () => {
+    expect(resolveStartupRoute({ ...onboardedUser, nip5Error: true })).toBe(
+      ROUTES.ONBOARDING_ERROR,
+    );
+  });
+
+  describe("guest browsing", () => {
+    it("sends a returning guest straight home instead of back into onboarding", () => {
+      expect(
+        resolveStartupRoute({
+          ...freshUser,
+          hasBeenOpenedBefore: true,
+          isBrowsingAsGuest: true,
+        }),
+      ).toBe(ROUTES.HOME);
+    });
+
+    it("still shows the welcome screen to a guest who has never opened the app", () => {
+      expect(
+        resolveStartupRoute({ ...freshUser, isBrowsingAsGuest: true }),
+      ).toBe(ROUTES.WELCOME);
+    });
+
+    it("lets the forceOnboarding dev flag override guest browsing", () => {
+      expect(
+        resolveStartupRoute({
+          ...freshUser,
+          hasBeenOpenedBefore: true,
+          isBrowsingAsGuest: true,
+          forceOnboarding: true,
+        }),
+      ).toBe(ROUTES.ONBOARDING);
+    });
+
+    it("sends a guest who has since completed onboarding home", () => {
+      expect(
+        resolveStartupRoute({ ...onboardedUser, isBrowsingAsGuest: true }),
+      ).toBe(ROUTES.HOME);
+    });
+
+    it("does not swallow a NIP-05 error for a guest who has since onboarded", () => {
+      expect(
+        resolveStartupRoute({
+          ...onboardedUser,
+          isBrowsingAsGuest: true,
+          nip5Error: true,
+        }),
+      ).toBe(ROUTES.ONBOARDING_ERROR);
+    });
+  });
+});

--- a/nr-app/src/utils/startupRoute.utils.ts
+++ b/nr-app/src/utils/startupRoute.utils.ts
@@ -1,0 +1,48 @@
+import { ROUTES } from "@/constants/routes";
+
+type StartupState = {
+  hasBeenOpenedBefore: boolean;
+  username: string | null;
+  npub: `npub${string}` | undefined;
+  nip5Error: boolean;
+  isBrowsingAsGuest: boolean;
+  forceOnboarding: boolean;
+  forceWelcome: boolean;
+};
+
+type StartupRoute =
+  | typeof ROUTES.WELCOME
+  | typeof ROUTES.ONBOARDING
+  | typeof ROUTES.ONBOARDING_ERROR
+  | typeof ROUTES.HOME;
+
+export function resolveStartupRoute({
+  hasBeenOpenedBefore,
+  username,
+  npub,
+  nip5Error,
+  isBrowsingAsGuest,
+  forceOnboarding,
+  forceWelcome,
+}: StartupState): StartupRoute {
+  if (forceWelcome || !hasBeenOpenedBefore) {
+    return ROUTES.WELCOME;
+  }
+
+  // A broken identity outranks guest browsing: it means we have a username and
+  // npub that Trustroots no longer vouches for, which the user must resolve.
+  if (nip5Error) {
+    return ROUTES.ONBOARDING_ERROR;
+  }
+
+  if (forceOnboarding) {
+    return ROUTES.ONBOARDING;
+  }
+
+  const hasIdentity = Boolean(username && npub);
+  if (hasIdentity || isBrowsingAsGuest) {
+    return ROUTES.HOME;
+  }
+
+  return ROUTES.ONBOARDING;
+}


### PR DESCRIPTION
Closes #236.

## The issue was smaller than it looked

#236 reads like an architectural change to the onboarding gate. It isn't. The layers underneath already support keyless browsing:

- **Reading needs no key.** Relay connect (`src/nostr/relays.nostr.ts`) and subscribe (`src/nostr/subscriptions.nostr.ts`) are plain, key-free calls — no NIP-42 AUTH, no signer. The map saga builds filters purely from visible plus codes and enabled layers. Only *publishing* needs the secret (`publish.saga.ts` → `signEventTemplate`, which throws without one).
- **The map already degrades to read-only** — `MapModal` swaps the compose form for a hint when there's no key.
- **There is no key guard inside the app.** No `app/(main)/_layout.tsx`; nothing re-checks once you're past the index route.

An unkeyed user could in fact *already* reach the map: the onboarding identity screen had a "Skip" button behind `useSkipOnboarding`, a flag that defaulted to `true`. (`areTestFeaturesEnabled` gated only the Settings *toggle*, not the button.)

## The actual defect

The choice didn't stick. The whole gate was one line in `app/index.tsx`:

```ts
const showOnboarding = !username || !npub || nip5Error || forceOnboarding;
```

That re-runs on every cold start, and a guest has neither `username` nor `npub` — so anyone who skipped got dumped back into onboarding on next launch. Completion was *inferred* from `username` + `npub` rather than recorded.

## What this does

- Adds a persisted `isBrowsingAsGuest` to the settings slice (already in the redux-persist whitelist), set when the user chooses to browse and cleared by `setUsername`, the de-facto "onboarding complete" signal.
- Removes the `useSkipOnboarding` feature flag and its dev toggle. The affordance is now always offered and relabelled **"Browse first"** — "Skip" reads like dismissing a chore; this states the actual offer.
- **Gives guests a way back.** The compose bar previously dead-ended them with "Set up your private key in settings to post." It now offers a **"Set up account"** button that dismisses the sheet and pushes into onboarding.
- Extracts the gate into `resolveStartupRoute()` so the routing rules are testable. A broken NIP-05 link deliberately **outranks** guest state — if a guest later onboards and their Trustroots link breaks, they still get the error screen rather than being silently dropped on the map. There's a test pinning that.

## Testing

`pnpm test` in `nr-app`: **94 passing** (85 on `main` + 9 new for `resolveStartupRoute`). No new lint or type errors.

⚠️ **Not yet verified in a simulator.** The routing rules are covered by unit tests, but the rendered "Browse first" button and the tap-through (browse → map → restart → still on map) have not been exercised on a device. Worth a manual pass before merge.

## Open question

Guests can reach onboarding from the map compose bar, but not from Settings. A persistent "Set up your account" entry point there may be worth adding.