### PR TITLE
feat(nr-app): add anonymous Umami analytics

### DIFF
--- a/nr-app/app/(main)/(views)/settings.tsx
+++ b/nr-app/app/(main)/(views)/settings.tsx
@@ -43,6 +43,7 @@ import {
   settingsSelectors,
 } from "@/redux/slices/settings.slice";
 import { navigateToEvent } from "@/utils/navigation.utils";
+import { trackEvent } from "@/services/analytics.service";
 import {
   EventJSONNotificationDataSchema,
   getFirstLabelValueFromEvent,
@@ -153,6 +154,9 @@ export default function SettingsScreen() {
   const areTestFeaturesEnabled = useAppSelector(
     settingsSelectors.selectAreTestFeaturesEnabled,
   ) as boolean;
+  const analyticsEnabled = useAppSelector(
+    settingsSelectors.selectAnalyticsEnabled,
+  );
 
   // Onboarding configuration flags.
   const { forceOnboarding, forceWelcome } = useAppSelector(selectFeatureFlags);
@@ -221,7 +225,15 @@ export default function SettingsScreen() {
       Toast.show("Notifications enabled", {
         duration: Toast.durations.SHORT,
       });
+      trackEvent("notifications_changed", {
+        action: "enable",
+        outcome: "success",
+      });
     } catch (error) {
+      trackEvent("notifications_changed", {
+        action: "enable",
+        outcome: "failure",
+      });
       Toast.show(`#eN1vKp Error: ${error}`, {
         duration: Toast.durations.LONG,
       });
@@ -234,7 +246,15 @@ export default function SettingsScreen() {
       Toast.show("Notifications disabled", {
         duration: Toast.durations.SHORT,
       });
+      trackEvent("notifications_changed", {
+        action: "disable",
+        outcome: "success",
+      });
     } catch (error) {
+      trackEvent("notifications_changed", {
+        action: "disable",
+        outcome: "failure",
+      });
       Toast.show(`#dN1vKp Error: ${error}`, {
         duration: Toast.durations.LONG,
       });
@@ -261,6 +281,11 @@ export default function SettingsScreen() {
 
     if (result.success) {
       setImportStatus("saved");
+      trackEvent("key_imported", {
+        method: result.type === "mnemonic" ? "mnemonic" : "nsec",
+        outcome: "success",
+        source: "settings",
+      });
       const message =
         result.type === "mnemonic"
           ? "Mnemonic imported successfully"
@@ -271,6 +296,10 @@ export default function SettingsScreen() {
       });
     } else {
       setImportStatus("failed");
+      trackEvent("key_imported", {
+        outcome: "failure",
+        source: "settings",
+      });
       Toast.show(
         "Failed to import key. Please check your input and try again.",
         {
@@ -495,6 +524,21 @@ export default function SettingsScreen() {
       </Section>
 
       <AppearanceSection />
+
+      <Section>
+        <Text variant="h2">Privacy</Text>
+        <Text variant="p">
+          Share anonymous app usage to help improve Nostroots. We never include
+          your identity, keys, messages, or location in analytics.
+        </Text>
+        <ToggleSwitch
+          label="Anonymous usage analytics"
+          value={analyticsEnabled}
+          onToggle={() => {
+            dispatch(settingsActions.setAnalyticsEnabled(!analyticsEnabled));
+          }}
+        />
+      </Section>
 
       <Section>
         <ToggleSwitch

--- a/nr-app/app/_layout.tsx
+++ b/nr-app/app/_layout.tsx
@@ -37,6 +37,10 @@ import { useUpdateOnForeground } from "@/hooks/useUpdateOnForeground";
 import { StatusBar } from "react-native";
 import { configureNavigationDispatch } from "@/utils/navigation.utils";
 import { NAV_THEME, THEME } from "@/utils/theme.utils";
+import {
+  setAnalyticsEnabled,
+  trackScreenView,
+} from "@/services/analytics.service";
 
 // Construct a new integration instance. This is needed to communicate between the integration and React
 const navigationIntegration = Sentry.reactNavigationIntegration({
@@ -67,6 +71,17 @@ function AppContent() {
   const colorSchemePreference = useAppSelector(
     settingsSelectors.selectColorScheme,
   );
+  const analyticsEnabled = useAppSelector(
+    settingsSelectors.selectAnalyticsEnabled,
+  );
+
+  useEffect(() => {
+    setAnalyticsEnabled(analyticsEnabled);
+  }, [analyticsEnabled]);
+
+  useEffect(() => {
+    if (pathname) trackScreenView(pathname);
+  }, [pathname]);
 
   useEffect(() => {
     const forceLightMode = FORCE_LIGHT_MODE_ROUTES.some((route) =>

--- a/nr-app/app/onboarding/backup-confirm.tsx
+++ b/nr-app/app/onboarding/backup-confirm.tsx
@@ -17,6 +17,7 @@ import {
 import { useAppSelector } from "@/redux/hooks";
 import { settingsSelectors } from "@/redux/slices/settings.slice";
 import { getBech32PrivateKey } from "nip06";
+import { trackEvent } from "@/services/analytics.service";
 
 async function verifyBackupInput(rawInput: string): Promise<boolean> {
   const input = rawInput.trim();
@@ -153,11 +154,19 @@ export default function OnboardingBackupConfirmScreen() {
     try {
       const ok = await verifyBackupInput(trimmed);
       if (!ok) {
+        trackEvent("onboarding_backup_confirmed", {
+          outcome: "mismatch",
+          source: from === "bridge" ? "bridge" : "legacy_key",
+        });
         setSuccess(false);
         setError(
           "That does not match your saved secret. Double-check and try again.",
         );
       } else {
+        trackEvent("onboarding_backup_confirmed", {
+          outcome: "success",
+          source: from === "bridge" ? "bridge" : "legacy_key",
+        });
         setSuccess(true);
         setError(null);
         setInput("");
@@ -169,12 +178,19 @@ export default function OnboardingBackupConfirmScreen() {
 
   const handleFinish = () => {
     if (!success) return;
+    trackEvent("onboarding_completed", {
+      method: from === "bridge" ? "bridge" : "generated_key",
+    });
     setInput("");
     setError(null);
     router.replace(ROUTES.HOME);
   };
 
   const handleBack = () => {
+    trackEvent("onboarding_backup", {
+      action: "back",
+      source: from === "bridge" ? "bridge" : "legacy_key",
+    });
     setInput("");
     setError(null);
     setSuccess(false);

--- a/nr-app/app/onboarding/error.tsx
+++ b/nr-app/app/onboarding/error.tsx
@@ -6,15 +6,18 @@ import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { ROUTES } from "@/constants/routes";
 import { AlertTriangleIcon } from "lucide-react-native";
+import { trackEvent } from "@/services/analytics.service";
 
 export default function OnboardingErrorScreen() {
   const router = useRouter();
 
   const handleContinue = () => {
+    trackEvent("onboarding_error", { action: "retry" });
     router.replace("/onboarding/trustroots");
   };
 
   const handleClose = () => {
+    trackEvent("onboarding_error", { action: "close" });
     router.replace(ROUTES.HOME);
   };
 

--- a/nr-app/app/onboarding/identity.tsx
+++ b/nr-app/app/onboarding/identity.tsx
@@ -8,6 +8,7 @@ import { ROUTES } from "@/constants/routes";
 import { IdCardLanyardIcon } from "lucide-react-native";
 import { settingsActions } from "@/redux/slices/settings.slice";
 import { useAppDispatch } from "@/redux/hooks";
+import { trackEvent } from "@/services/analytics.service";
 
 export default function OnboardingIdentityScreen() {
   const router = useRouter();
@@ -18,10 +19,12 @@ export default function OnboardingIdentityScreen() {
   };
 
   const goNext = () => {
+    trackEvent("onboarding_identity", { action: "continue" });
     router.push("/onboarding/trustroots");
   };
 
   const goBrowse = () => {
+    trackEvent("onboarding_identity", { action: "browse" });
     dispatch(settingsActions.setIsBrowsingAsGuest(true));
     router.replace(ROUTES.HOME);
   };

--- a/nr-app/app/onboarding/key.tsx
+++ b/nr-app/app/onboarding/key.tsx
@@ -16,6 +16,7 @@ import { setPrivateKeyPromiseAction } from "@/redux/sagas/keystore.saga";
 import { settingsActions } from "@/redux/slices/settings.slice";
 import { KeyIcon } from "lucide-react-native";
 import { getBech32PrivateKey } from "nip06";
+import { trackEvent } from "@/services/analytics.service";
 
 export default function OnboardingKeyScreen() {
   const router = useRouter();
@@ -61,10 +62,19 @@ export default function OnboardingKeyScreen() {
     if (result.success) {
       setKeySaved(true);
       dispatch(settingsActions.setKeyWasImported(true));
+      trackEvent("onboarding_key_saved", {
+        method: result.type === "mnemonic" ? "mnemonic" : "nsec",
+        outcome: "success",
+      });
+    } else {
+      trackEvent("onboarding_key_saved", {
+        method: "import",
+        outcome: "failure",
+      });
     }
   };
 
-  const saveGeneratedMnemonic = async () => {
+  const saveGeneratedMnemonic = useCallback(async () => {
     if (!mnemonic || !mnemonicConfirmed) {
       setMnemonicError("Please save and confirm your words before continuing.");
       return;
@@ -73,11 +83,19 @@ export default function OnboardingKeyScreen() {
     try {
       dispatch(setPrivateKeyPromiseAction.request({ mnemonic }));
       dispatch(settingsActions.setKeyWasImported(false));
+      trackEvent("onboarding_key_saved", {
+        method: "generated",
+        outcome: "success",
+      });
     } catch (error) {
+      trackEvent("onboarding_key_saved", {
+        method: "generated",
+        outcome: "failure",
+      });
       console.error("Failed to save mnemonic", error);
       setMnemonicError("We could not set up this key. Please try again.");
     }
-  };
+  }, [dispatch, mnemonic, mnemonicConfirmed]);
 
   const goBack = () => {
     if (router.canGoBack()) {
@@ -88,14 +106,13 @@ export default function OnboardingKeyScreen() {
   };
 
   const goNext = useCallback(async () => {
-    if (currentTab === "existing") {
-      await saveExistingKey();
-    } else {
+    if (currentTab === "generate") {
       await saveGeneratedMnemonic();
     }
 
+    trackEvent("onboarding_key_completed", { method: currentTab });
     router.push("/onboarding/link");
-  }, [currentTab, saveExistingKey, saveGeneratedMnemonic, router]);
+  }, [currentTab, saveGeneratedMnemonic, router]);
 
   const canContinue =
     currentTab === "existing"
@@ -120,9 +137,11 @@ export default function OnboardingKeyScreen() {
       <View className="flex w-full flex-col gap-6">
         <Tabs
           value={currentTab}
-          onValueChange={(value) =>
-            setCurrentTab(value as "existing" | "generate")
-          }
+          onValueChange={(value) => {
+            const method = value as "existing" | "generate";
+            setCurrentTab(method);
+            trackEvent("onboarding_key_method_selected", { method });
+          }}
         >
           <TabsList>
             <TabsTrigger value="generate">

--- a/nr-app/app/onboarding/link.tsx
+++ b/nr-app/app/onboarding/link.tsx
@@ -25,6 +25,7 @@ import {
   SquareArrowOutUpRight,
 } from "lucide-react-native";
 import Toast from "react-native-root-toast";
+import { trackEvent } from "@/services/analytics.service";
 
 interface StepCardProps {
   stepNumber: number;
@@ -66,6 +67,7 @@ export default function OnboardingLinkScreen() {
     (publicKeyHex ? nip19.npubEncode(publicKeyHex) : undefined);
 
   const openTrustrootsNetworks = () => {
+    trackEvent("onboarding_trustroots_networks_opened");
     Linking.openURL("https://www.trustroots.org/profile/edit/networks");
   };
 
@@ -85,6 +87,10 @@ export default function OnboardingLinkScreen() {
   const verifyAndLink = useCallback(
     async (usernameOverride?: string) => {
       if (!npub) {
+        trackEvent("onboarding_link", {
+          outcome: "missing_key",
+          method: "nip05",
+        });
         setLinkError(
           "We could not read your Nostr key. Please go back and retry.",
         );
@@ -96,6 +102,10 @@ export default function OnboardingLinkScreen() {
       );
 
       if (!validation.success) {
+        trackEvent("onboarding_link", {
+          outcome: "invalid_input",
+          method: "nip05",
+        });
         setLinkError(validation.error);
         return;
       }
@@ -113,6 +123,10 @@ export default function OnboardingLinkScreen() {
         console.log("[link] NIP-05 profile result:", JSON.stringify(profile));
 
         if (!profile?.pubkey) {
+          trackEvent("onboarding_link", {
+            outcome: "not_found",
+            method: "nip05",
+          });
           console.warn(
             "[link] NIP-05 lookup returned no pubkey for",
             identifier,
@@ -129,6 +143,10 @@ export default function OnboardingLinkScreen() {
         console.log("[link] NIP-05 npub:", nip05Npub, "local npub:", npub);
 
         if (nip05Npub !== npub) {
+          trackEvent("onboarding_link", {
+            outcome: "mismatch",
+            method: "nip05",
+          });
           console.warn("[link] NIP-05 pubkey mismatch", { nip05Npub, npub });
           setLinkStatus("error");
           setLinkError(
@@ -148,7 +166,15 @@ export default function OnboardingLinkScreen() {
 
         dispatch(settingsActions.setUsername(normalizedUsername));
         setLinkStatus("linked");
+        trackEvent("onboarding_link", {
+          outcome: "success",
+          method: "nip05",
+        });
       } catch (error) {
+        trackEvent("onboarding_link", {
+          outcome: "failure",
+          method: "nip05",
+        });
         console.error("[link] verifyAndLink error:", error);
         setLinkStatus("error");
         setLinkError(
@@ -193,8 +219,10 @@ export default function OnboardingLinkScreen() {
 
   const goNext = () => {
     if (keyWasImported) {
+      trackEvent("onboarding_completed", { method: "imported_key" });
       router.replace(ROUTES.HOME);
     } else {
+      trackEvent("onboarding_backup_started", { source: "legacy_key" });
       router.push("/onboarding/backup-confirm");
     }
   };

--- a/nr-app/app/onboarding/trustroots.tsx
+++ b/nr-app/app/onboarding/trustroots.tsx
@@ -19,6 +19,7 @@ import {
   settingsSelectors,
 } from "@/redux/slices/settings.slice";
 import { validateTrustrootsUsername } from "@/utils/trustrootsUsername.utils";
+import { trackEvent } from "@/services/analytics.service";
 
 type TrustrootsScreenState =
   | "idle"
@@ -110,8 +111,16 @@ export default function OnboardingTrustrootsScreen() {
       try {
         setScreenState("profile-publishing");
         await finalizeTrustrootsProfilePublish(username, dispatch);
+        trackEvent("onboarding_profile_publish", {
+          method: "bridge",
+          outcome: "success",
+        });
         router.replace("/onboarding/backup-confirm?from=bridge");
       } catch (error) {
+        trackEvent("onboarding_profile_publish", {
+          method: "bridge",
+          outcome: "failure",
+        });
         console.error("Failed to publish Trustroots profile", error);
         setScreenState("profile-retry");
         setStatusMessage(
@@ -126,6 +135,10 @@ export default function OnboardingTrustrootsScreen() {
     const result = validateTrustrootsUsername(usernameInput);
 
     if (!result.success) {
+      trackEvent("onboarding_verification_code", {
+        action: "request",
+        outcome: "invalid_input",
+      });
       setFieldError(result.error);
       return;
     }
@@ -141,6 +154,10 @@ export default function OnboardingTrustrootsScreen() {
       setCode("");
       setStatusMessage("Check your Trustroots email for a six-digit code.");
       setScreenState("code-entry");
+      trackEvent("onboarding_verification_code", {
+        action: "request",
+        outcome: "success",
+      });
     } catch (error) {
       if (error instanceof NrBridgeError && error.code === "already-pending") {
         dispatch(settingsActions.setPendingTrustrootsUsername(result.username));
@@ -150,15 +167,27 @@ export default function OnboardingTrustrootsScreen() {
           "A verification code is already pending. Check your Trustroots email.",
         );
         setScreenState("code-entry");
+        trackEvent("onboarding_verification_code", {
+          action: "request",
+          outcome: "already_pending",
+        });
         return;
       }
 
       if (error instanceof NrBridgeError && error.code === "not-found") {
         setFieldError("Trustroots username not found.");
         setScreenState("idle");
+        trackEvent("onboarding_verification_code", {
+          action: "request",
+          outcome: "not_found",
+        });
         return;
       }
 
+      trackEvent("onboarding_verification_code", {
+        action: "request",
+        outcome: "failure",
+      });
       setStatusMessage(getRequestErrorMessage(error));
       setScreenState("idle");
     }
@@ -185,7 +214,15 @@ export default function OnboardingTrustrootsScreen() {
     try {
       const { npub } = await ensureOnboardingIdentity(dispatch);
       await authenticateWithCode({ username, npub, code });
+      trackEvent("onboarding_verification_code", {
+        action: "authenticate",
+        outcome: "success",
+      });
     } catch (error) {
+      trackEvent("onboarding_verification_code", {
+        action: "authenticate",
+        outcome: "failure",
+      });
       console.error("Failed to authenticate Trustroots code", error);
       resetToUsernameEntry(AUTHENTICATION_FAILURE_MESSAGE);
       return;
@@ -216,10 +253,12 @@ export default function OnboardingTrustrootsScreen() {
   ]);
 
   const handleSignup = async () => {
+    trackEvent("onboarding_signup_opened");
     await WebBrowser.openBrowserAsync("https://www.trustroots.org/signup");
   };
 
   const goLegacyKeyFlow = () => {
+    trackEvent("onboarding_method_selected", { method: "legacy_key" });
     router.push("/onboarding/key");
   };
 

--- a/nr-app/app/welcome.tsx
+++ b/nr-app/app/welcome.tsx
@@ -4,11 +4,13 @@ import { View } from "react-native";
 
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
+import { trackEvent } from "@/services/analytics.service";
 
 export default function WelcomeScreen() {
   const router = useRouter();
 
   const handleGetStarted = () => {
+    trackEvent("onboarding_started");
     router.replace("/onboarding");
   };
 

--- a/nr-app/src/components/AddNoteForm.tsx
+++ b/nr-app/src/components/AddNoteForm.tsx
@@ -22,6 +22,7 @@ import Toast from "react-native-root-toast";
 import { Button } from "./ui/button";
 import { Icon } from "./ui/icon";
 import { Text } from "./ui/text";
+import { trackEvent } from "@/services/analytics.service";
 
 interface OptimisticNote {
   id: string;
@@ -151,7 +152,15 @@ export default function AddNoteForm({
       if (effectiveIntent) {
         onSignalSent?.();
       }
+      trackEvent("note_published", {
+        intent: effectiveIntent ?? "none",
+        outcome: "success",
+      });
     } catch {
+      trackEvent("note_published", {
+        intent: effectiveIntent ?? "none",
+        outcome: "failure",
+      });
       // Mark as failed
       setOptimisticNotes((prev) =>
         prev.map((n) =>
@@ -199,7 +208,9 @@ export default function AddNoteForm({
           ),
         );
         setOptimisticNotes((prev) => prev.filter((n) => n.id !== note.id));
+        trackEvent("note_publish_retried", { outcome: "success" });
       } catch {
+        trackEvent("note_publish_retried", { outcome: "failure" });
         setOptimisticNotes((prev) =>
           prev.map((n) =>
             n.id === note.id ? { ...n, status: "failed" as const } : n,

--- a/nr-app/src/redux/slices/settings.slice.ts
+++ b/nr-app/src/redux/slices/settings.slice.ts
@@ -12,6 +12,7 @@ type SettingsState = {
   forceOnboarding: boolean;
   forceWelcome: boolean;
   colorScheme: ColorSchemePreference;
+  analyticsEnabled: boolean;
   keyWasImported: boolean;
   hasAcknowledgedExperimentalLayers: boolean;
   pendingTrustrootsUsername: string | null;
@@ -27,6 +28,7 @@ const initialState: SettingsState = {
   forceOnboarding: false,
   forceWelcome: false,
   colorScheme: "system",
+  analyticsEnabled: true,
   keyWasImported: false,
   hasAcknowledgedExperimentalLayers: false,
   pendingTrustrootsUsername: null,
@@ -61,6 +63,9 @@ export const settingsSlice = createSlice({
     },
     setColorScheme: (state, action: PayloadAction<ColorSchemePreference>) => {
       state.colorScheme = action.payload;
+    },
+    setAnalyticsEnabled: (state, action: PayloadAction<boolean>) => {
+      state.analyticsEnabled = action.payload;
     },
     setKeyWasImported: (state, action: PayloadAction<boolean>) => {
       state.keyWasImported = action.payload;
@@ -97,6 +102,7 @@ export const settingsSlice = createSlice({
     selectIsDataLoaded: (state) => state.isDataLoaded,
     selectIsBrowsingAsGuest: (state) => state.isBrowsingAsGuest,
     selectColorScheme: (state) => state.colorScheme,
+    selectAnalyticsEnabled: (state) => state.analyticsEnabled ?? true,
     selectKeyWasImported: (state) => state.keyWasImported,
     selectHasAcknowledgedExperimentalLayers: (state) =>
       state.hasAcknowledgedExperimentalLayers,

--- a/nr-app/src/services/analytics.service.test.ts
+++ b/nr-app/src/services/analytics.service.test.ts
@@ -1,0 +1,43 @@
+import {
+  createAnalyticsPayload,
+  sanitizeAnalyticsData,
+} from "./analytics.service";
+
+describe("analytics service", () => {
+  it("removes query parameters and fragments from screen paths", () => {
+    const payload = createAnalyticsPayload(
+      "/onboarding/backup-confirm?from=bridge#secret",
+    );
+
+    expect(payload.url).toBe("/onboarding/backup-confirm");
+    expect(payload.title).toBe("/onboarding/backup-confirm");
+    expect(payload.website).toBe("ba3d08c7-1790-45e6-9bfb-51e6cfbd0c50");
+  });
+
+  it("only permits anonymous categorical event data", () => {
+    expect(
+      sanitizeAnalyticsData({
+        method: "Bridge Flow",
+        outcome: "Success",
+        username: "private-user",
+        content: "private note",
+      }),
+    ).toEqual({
+      method: "bridge_flow",
+      outcome: "success",
+    });
+  });
+
+  it("sanitizes event names and ignores data on page views", () => {
+    expect(
+      createAnalyticsPayload("/welcome", "Onboarding Started!", {
+        source: "Welcome Screen",
+      }),
+    ).toMatchObject({
+      name: "onboarding_started_",
+      data: { source: "welcome_screen" },
+    });
+
+    expect(createAnalyticsPayload("/welcome")).not.toHaveProperty("data");
+  });
+});

--- a/nr-app/src/services/analytics.service.ts
+++ b/nr-app/src/services/analytics.service.ts
@@ -1,0 +1,138 @@
+import Constants from "expo-constants";
+import { Dimensions, Platform } from "react-native";
+
+const UMAMI_ENDPOINT = "https://1p.trustroots.org/api/send";
+const UMAMI_WEBSITE_ID = "ba3d08c7-1790-45e6-9bfb-51e6cfbd0c50";
+const UMAMI_HOSTNAME = "nr-app";
+
+const ALLOWED_DATA_KEYS = new Set([
+  "action",
+  "intent",
+  "method",
+  "outcome",
+  "source",
+]);
+
+type AnalyticsDataValue = boolean | number | string;
+export type AnalyticsEventData = Record<string, AnalyticsDataValue>;
+
+type UmamiPayload = {
+  website: string;
+  hostname: string;
+  screen: string;
+  language: string;
+  title: string;
+  url: string;
+  referrer: string;
+  name?: string;
+  data?: AnalyticsEventData;
+};
+
+let analyticsEnabled = false;
+let currentScreen = "/";
+
+function getLanguage(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().locale || "en";
+  } catch {
+    return "en";
+  }
+}
+
+function sanitizeRoute(route: string): string {
+  const path = route.split(/[?#]/, 1)[0].trim();
+  if (!path.startsWith("/")) return "/";
+  return path.slice(0, 120) || "/";
+}
+
+function sanitizeName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "_")
+    .slice(0, 50);
+}
+
+export function sanitizeAnalyticsData(
+  data?: AnalyticsEventData,
+): AnalyticsEventData | undefined {
+  if (!data) return undefined;
+
+  const sanitized = Object.entries(data).reduce<AnalyticsEventData>(
+    (result, [key, value]) => {
+      if (!ALLOWED_DATA_KEYS.has(key)) return result;
+
+      if (typeof value === "string") {
+        const safeValue = value
+          .trim()
+          .toLowerCase()
+          .replace(/[^a-z0-9_:+.-]/g, "_")
+          .slice(0, 80);
+        if (safeValue) result[key] = safeValue;
+      } else if (typeof value === "boolean" || typeof value === "number") {
+        result[key] = value;
+      }
+
+      return result;
+    },
+    {},
+  );
+
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+}
+
+export function setAnalyticsEnabled(enabled: boolean): void {
+  analyticsEnabled = enabled;
+}
+
+export function createAnalyticsPayload(
+  route: string,
+  name?: string,
+  data?: AnalyticsEventData,
+): UmamiPayload {
+  const { width, height } = Dimensions.get("screen");
+  const url = sanitizeRoute(route);
+  const eventName = name ? sanitizeName(name) : undefined;
+
+  return {
+    website: UMAMI_WEBSITE_ID,
+    hostname: UMAMI_HOSTNAME,
+    screen: `${Math.round(width)}x${Math.round(height)}`,
+    language: getLanguage(),
+    title: url,
+    url,
+    referrer: "",
+    ...(eventName ? { name: eventName } : {}),
+    ...(eventName && data ? { data: sanitizeAnalyticsData(data) } : {}),
+  };
+}
+
+async function send(payload: UmamiPayload): Promise<void> {
+  if (__DEV__ || Platform.OS === "web" || !analyticsEnabled) return;
+
+  const version = Constants.expoConfig?.version ?? "unknown";
+
+  try {
+    await fetch(UMAMI_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": `Nostroots/${version} (${Platform.OS})`,
+      },
+      body: JSON.stringify({ type: "event", payload }),
+    });
+  } catch {
+    // Analytics must never interfere with app behavior.
+  }
+}
+
+export function trackScreenView(route: string): void {
+  currentScreen = sanitizeRoute(route);
+  void send(createAnalyticsPayload(currentScreen));
+}
+
+export function trackEvent(name: string, data?: AnalyticsEventData): void {
+  const eventName = sanitizeName(name);
+  if (!eventName) return;
+  void send(createAnalyticsPayload(currentScreen, eventName, data));
+}


### PR DESCRIPTION
## Summary

- add production-only Umami screen and event tracking to nr-app
- capture the onboarding funnel, key app outcomes, and anonymous categorical metadata
- add a persistent Settings opt-out and runtime metadata allowlist
- exclude development builds and Expo Web from collection

## Why

Anonymous product analytics will show where onboarding users drop out and which key flows succeed or fail, without sending identities, keys, messages, or precise location data.

## Validation

- `npx jest --runInBand` — 17 suites, 104 tests passed
- targeted ESLint pass for the analytics service and affected screens
- `git diff --check`
