### PR TITLE
test(nr-app): add Maestro E2E flows for onboarding

### DIFF
--- a/nr-app/.maestro/README.md
+++ b/nr-app/.maestro/README.md
@@ -1,0 +1,97 @@
+# nr-app end-to-end tests
+
+[Maestro](https://maestro.mobile.dev) flows covering onboarding.
+
+## Setup
+
+Install the Maestro CLI once:
+
+```bash
+curl -Ls "https://get.maestro.mobile.dev" | bash
+```
+
+It appends itself to your shell profile. Open a new shell, or:
+
+```bash
+export PATH="$PATH:$HOME/.maestro/bin"
+```
+
+## Running
+
+Build and install a **Release** build on the simulator:
+
+```bash
+cd nr-app
+SENTRY_DISABLE_AUTO_UPLOAD=true pnpm exec expo run:ios --configuration Release
+```
+
+Then, with the simulator running:
+
+```bash
+cd nr-app
+pnpm test:e2e
+```
+
+Run one flow:
+
+```bash
+maestro test .maestro/flows/onboarding-import.yaml
+```
+
+To watch a flow while iterating on it, `maestro test --continuous <file>`.
+
+### Why Release and not a dev build
+
+A dev build does not work for these flows. `launchApp: clearState: true` wipes
+the dev client's stored Metro URL, so it lands on "No development servers
+found"; sending it back to Metro with a deep link then triggers the dev client's
+developer-menu sheet, whose text is not in the accessibility hierarchy and so
+cannot be reliably dismissed. A Release build embeds the JS bundle, needs no
+Metro, and gives a genuine cold start.
+
+`SENTRY_DISABLE_AUTO_UPLOAD=true` is needed because the Release build otherwise
+runs sentry-cli source map upload, which fails without an auth token.
+
+## Flows
+
+| Flow | What it covers |
+| --- | --- |
+| `flows/onboarding-generate.yaml` | Fresh install through to a newly generated mnemonic, ending on the link screen |
+| `flows/onboarding-import.yaml` | Fresh install importing a fixed test nsec, asserting the derived npub on the link screen |
+
+Both share `subflows/open-key-screen.yaml`, which wipes state and walks to the
+key step.
+
+## What is not covered, and why
+
+`app/onboarding/trustroots.tsx` is the primary onboarding branch. It requests a
+six-digit code through `nr-bridge` and delivers it by email, so it cannot be
+driven end to end without a mock bridge. The flows take the legacy key path
+instead (`I've already set my key on Trustroots`).
+
+Both flows stop at the link screen. `link.tsx` gates its Finish button on a live
+NIP-05 lookup against trustroots.org that must match the local npub, so reaching
+the home screen needs a real linked Trustroots account.
+
+## Known deviation: the welcome screen
+
+A fresh install lands on `onboarding/identity`, not `welcome`. `app/index.tsx`
+renders `Redirect -> WELCOME`, but its own effect sets `hasBeenOpenedBefore` in
+the same commit, and the re-render swaps in `Redirect -> ONBOARDING` before the
+first redirect navigates.
+
+The subflow encodes this current behaviour so the flows pass. It is a deviation
+from what the code intends, not a decision. If the redirect race is fixed, add
+the `welcome-get-started` tap back to the top of the subflow.
+
+## Selectors
+
+Flows select on `testID`, never on visible copy, so rewording a button does not
+break them. When you add a control that a flow needs to reach, give it a
+`testID` rather than matching its text.
+
+## CI
+
+These do not run in CI. `.github/workflows/test.yml` is a plain ubuntu Node and
+Deno job with no simulator, and adding one would put roughly twenty slow minutes
+on every push. Run them locally when you touch onboarding.

--- a/nr-app/.maestro/flows/onboarding-generate.yaml
+++ b/nr-app/.maestro/flows/onboarding-generate.yaml
@@ -1,0 +1,29 @@
+appId: org.trustroots.nostroots
+name: Onboarding - generate a new key
+---
+- runFlow: ../subflows/open-key-screen.yaml
+
+- tapOn:
+    id: "onboarding-key-tab-generate"
+
+# The mnemonic is generated on mount and rendered masked.
+- tapOn:
+    id: "onboarding-key-mnemonic-input-visibility-toggle"
+- assertVisible:
+    id: "onboarding-key-mnemonic-input"
+    text: "(\\w+ ){11}\\w+"
+
+- tapOn:
+    id: "onboarding-key-mnemonic-confirm"
+- assertVisible: "Saved"
+
+- tapOn:
+    id: "onboarding-key-continue"
+
+- extendedWaitUntil:
+    visible:
+      id: "onboarding-link-npub"
+    timeout: 20000
+- assertVisible:
+    id: "onboarding-link-npub"
+    text: "npub1.*"

--- a/nr-app/.maestro/flows/onboarding-import.yaml
+++ b/nr-app/.maestro/flows/onboarding-import.yaml
@@ -1,0 +1,36 @@
+appId: org.trustroots.nostroots
+name: Onboarding - import an existing key
+env:
+  # Private key 0x00...01. Synthetic, test-only, never use it for anything real.
+  TEST_NSEC: "nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsmhltgl"
+  TEST_NPUB: "npub10xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqpkge6d"
+---
+- runFlow: ../subflows/open-key-screen.yaml
+
+- tapOn:
+    id: "onboarding-key-tab-import"
+
+- tapOn:
+    id: "onboarding-key-import-input"
+- inputText: ${TEST_NSEC}
+# hideKeyboard does not work against this input; tap inert copy to dismiss.
+- tapOn: "Import Your Trustroots Key"
+
+- tapOn:
+    id: "onboarding-key-import-save"
+- extendedWaitUntil:
+    visible: "Saved"
+    timeout: 15000
+
+- tapOn:
+    id: "onboarding-key-continue"
+
+# The npub shown here is derived from the stored key, so it proves the whole
+# path: SecureStore write, keystore read, bech32 derivation, Redux, render.
+- extendedWaitUntil:
+    visible:
+      id: "onboarding-link-npub"
+    timeout: 20000
+- assertVisible:
+    id: "onboarding-link-npub"
+    text: ${TEST_NPUB}

--- a/nr-app/.maestro/subflows/open-key-screen.yaml
+++ b/nr-app/.maestro/subflows/open-key-screen.yaml
@@ -1,0 +1,33 @@
+appId: org.trustroots.nostroots
+name: Open the key step from a clean install
+---
+# clearState alone is not enough: expo-secure-store keeps the private key in the
+# iOS keychain, which survives an app data wipe.
+- clearKeychain
+- launchApp:
+    clearState: true
+
+# NOTE: a fresh install lands on identity, not welcome. app/index.tsx renders
+# Redirect->WELCOME, then its own effect sets hasBeenOpenedBefore, and the
+# re-render swaps in Redirect->ONBOARDING before the first redirect navigates.
+# This encodes today's behaviour, not the intended behaviour. If the welcome
+# screen is fixed, add the welcome-get-started tap back here.
+- extendedWaitUntil:
+    visible:
+      id: "onboarding-identity-continue"
+    timeout: 30000
+- tapOn:
+    id: "onboarding-identity-continue"
+
+# The email path needs nr-bridge and a real inbox, so take the legacy key path.
+- extendedWaitUntil:
+    visible:
+      id: "onboarding-trustroots-legacy-key"
+    timeout: 15000
+- tapOn:
+    id: "onboarding-trustroots-legacy-key"
+
+- extendedWaitUntil:
+    visible:
+      id: "onboarding-key-tab-generate"
+    timeout: 15000

--- a/nr-app/app/onboarding/identity.tsx
+++ b/nr-app/app/onboarding/identity.tsx
@@ -53,6 +53,7 @@ export default function OnboardingIdentityScreen() {
           <Button variant="secondary" onPress={goBack} size="lg" title="Back" />
         )}
         <Button
+          testID="onboarding-identity-continue"
           variant="secondary"
           onPress={goNext}
           size="lg"

--- a/nr-app/app/onboarding/key.tsx
+++ b/nr-app/app/onboarding/key.tsx
@@ -125,10 +125,10 @@ export default function OnboardingKeyScreen() {
           }
         >
           <TabsList>
-            <TabsTrigger value="generate">
+            <TabsTrigger testID="onboarding-key-tab-generate" value="generate">
               <Text>Generate</Text>
             </TabsTrigger>
-            <TabsTrigger value="existing">
+            <TabsTrigger testID="onboarding-key-tab-import" value="existing">
               <Text>Import</Text>
             </TabsTrigger>
           </TabsList>
@@ -142,6 +142,7 @@ export default function OnboardingKeyScreen() {
                 <Text className="text-xs text-red-500">{importError}</Text>
               )}
               <KeyInput
+                testID="onboarding-key-import-input"
                 value={existingKeyInput}
                 onChangeText={setExistingKeyInput}
                 placeholder="Paste your nsec or mnemonic"
@@ -149,6 +150,7 @@ export default function OnboardingKeyScreen() {
                 showPasteButton={true}
               />
               <Button
+                testID="onboarding-key-import-save"
                 size="lg"
                 title={keySaved ? "Saved" : isImporting ? "Saving..." : "Save"}
                 disabled={isImporting || keySaved}
@@ -163,6 +165,7 @@ export default function OnboardingKeyScreen() {
                 <Text className="text-xs text-red-500">{mnemonicError}</Text>
               )}
               <KeyInput
+                testID="onboarding-key-mnemonic-input"
                 value={mnemonic}
                 onChangeText={setMnemonic}
                 placeholder=""
@@ -173,6 +176,7 @@ export default function OnboardingKeyScreen() {
                 showCopyButton={true}
               />
               <Button
+                testID="onboarding-key-mnemonic-confirm"
                 size="lg"
                 title={
                   mnemonicConfirmed
@@ -196,6 +200,7 @@ export default function OnboardingKeyScreen() {
           title="Back"
         />
         <Button
+          testID="onboarding-key-continue"
           variant="secondary"
           onPress={goNext}
           size="lg"

--- a/nr-app/app/onboarding/link.tsx
+++ b/nr-app/app/onboarding/link.tsx
@@ -212,6 +212,7 @@ export default function OnboardingLinkScreen() {
             Tap on it to copy it to clipboard.
           </Text>
           <Text
+            testID="onboarding-link-npub"
             className="text-sm bg-muted text-foreground rounded-md p-3 w-full text-left"
             numberOfLines={1}
             onPress={handleCopy}

--- a/nr-app/app/onboarding/trustroots.tsx
+++ b/nr-app/app/onboarding/trustroots.tsx
@@ -360,6 +360,7 @@ export default function OnboardingTrustrootsScreen() {
           disabled={isBusy}
         />
         <Button
+          testID="onboarding-trustroots-legacy-key"
           variant="outline"
           textClassName="text-white"
           onPress={goLegacyKeyFlow}

--- a/nr-app/app/welcome.tsx
+++ b/nr-app/app/welcome.tsx
@@ -37,6 +37,7 @@ export default function WelcomeScreen() {
 
       <View className="w-full max-w-xs">
         <Button
+          testID="welcome-get-started"
           onPress={handleGetStarted}
           title="Get Started"
           size="lg"

--- a/nr-app/package.json
+++ b/nr-app/package.json
@@ -10,6 +10,7 @@
     "web": "expo start --web",
     "test": "jest",
     "test:watch": "jest --watchAll",
+    "test:e2e": "maestro test .maestro/flows",
     "lint": "eslint .",
     "prepare": "cd .. && husky nr-app/.husky",
     "build:android-development": "eas build --platform android --profile development --non-interactive",

--- a/nr-app/src/components/KeyInput.tsx
+++ b/nr-app/src/components/KeyInput.tsx
@@ -22,6 +22,7 @@ interface KeyInputProps {
   onRegenerate?: (newValue: string) => void;
   showCopyButton?: boolean;
   showPasteButton?: boolean;
+  testID?: string;
 }
 
 export function KeyInput({
@@ -34,6 +35,7 @@ export function KeyInput({
   onRegenerate,
   showCopyButton = false,
   showPasteButton = false,
+  testID,
 }: KeyInputProps) {
   const [showKey, setShowKey] = useState(false);
 
@@ -84,6 +86,7 @@ export function KeyInput({
     <View className="flex gap-2">
       <View className="relative">
         <TextInput
+          testID={testID}
           secureTextEntry={!showKey}
           autoCapitalize="none"
           autoCorrect={false}
@@ -94,6 +97,7 @@ export function KeyInput({
           editable={!disabled}
         />
         <Pressable
+          testID={testID ? `${testID}-visibility-toggle` : undefined}
           onPress={() => setShowKey(!showKey)}
           disabled={disabled}
           className="absolute right-3 top-3"


### PR DESCRIPTION
Introduces the first E2E tooling for `nr-app`, which until now had jest unit tests only, no E2E runner, and no `testID` anywhere in the app.

## Runner

Maestro — the runner Expo recommends. No native project changes, no extra native dependencies; it drives an ordinary build on a simulator.

Detox was rejected as too much native config and maintenance for the repo's first E2E test. Playwright against `expo start --web` was rejected because `expo-secure-store` has no web implementation, and the keystore is the centre of onboarding — the web build would exercise a different codepath than the shipped app.

## Flows

| Flow | Covers |
| --- | --- |
| `onboarding-generate.yaml` | Fresh install → generate a mnemonic → link screen |
| `onboarding-import.yaml` | Fresh install → import a fixed test nsec → assert the **derived npub** on the link screen |

The import flow is the load-bearing one. The fixed keypair makes the final assertion a real check over SecureStore write → keystore read → bech32 derivation → Redux → render, rather than "a screen appeared".

Both share `subflows/open-key-screen.yaml`.

## Verified

```
2/2 Flows Passed in 35s
```

Against an iOS simulator Release build. `pnpm lint` reports the same 22 problems (5 errors) on this branch as on `main` — all pre-existing, none in lines this PR touches. The source diff is `testID` props only.

## Release build, not a dev build

A dev build does not work here. `clearState: true` wipes the dev client's stored Metro URL, stranding it on "No development servers found"; deep-linking back to Metro then triggers the developer-menu sheet, whose text is absent from the accessibility hierarchy and so cannot be reliably dismissed. Release embeds the bundle, needs no Metro, and cold starts cleanly. Documented in `.maestro/README.md`.

## Scope — please read

This covers **less of onboarding than the title suggests**, for reasons in the code rather than choices made here:

- `onboarding/trustroots.tsx` is the *primary* branch and is not covered. It requests a six-digit code through `nr-bridge` and delivers it by email; driving it needs a mock bridge.
- Both flows stop at the link screen. `link.tsx` gates Finish on a live NIP-05 lookup against trustroots.org matching the local npub, so nothing reaches the home screen without a real linked account.

What is covered is the deterministic legacy key branch.

## Product bug surfaced, not fixed

A fresh install lands on `onboarding/identity`, **never showing the welcome screen**. `app/index.tsx` renders `Redirect -> WELCOME`, but its own effect sets `hasBeenOpenedBefore` in the same commit, and the re-render swaps in `Redirect -> ONBOARDING` before the first redirect navigates.

The subflow encodes current behaviour with a comment so the flows pass honestly. Fixing the race is product code and out of scope — worth its own issue.

## No CI

`test.yml` is a plain ubuntu Node/Deno job with no simulator; adding one would put ~20 slow, flaky minutes on every push. Run locally when touching onboarding.