### PR TITLE
test(nr-app): establish Jest coverage and PR overview

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,18 @@ name: Test
 
 on:
   workflow_call:
+  pull_request:
+    branches: [main]
+    paths:
+      - "nr-app/**"
+      - ".github/workflows/test.yml"
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -28,5 +36,125 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Run tests
-        run: pnpm test
+      - name: Lint nr-app
+        run: pnpm --filter nr-app lint
+
+      - name: Test nr-app with coverage
+        id: nr-app-tests
+        continue-on-error: true
+        run: pnpm test:app:ci
+
+      - name: Test nr-common
+        run: pnpm test:common
+
+      - name: Upload nr-app coverage
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: nr-app-coverage-${{ github.run_id }}
+          path: nr-app/coverage
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Update nr-app pull request test overview
+        if: always() && github.event_name == 'pull_request' && github.workflow == 'Test' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v8
+        env:
+          NR_APP_TEST_OUTCOME: ${{ steps.nr-app-tests.outcome }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- nr-app-test-overview -->';
+            const e2eStart = '<!-- nr-app-e2e-start -->';
+            const e2eEnd = '<!-- nr-app-e2e-end -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: issue_number,
+              per_page: 100,
+            });
+            if (!files.some(file => file.filename.startsWith('nr-app/'))) {
+              core.info('PR does not touch nr-app; skipping test overview.');
+              return;
+            }
+
+            const readJson = path =>
+              fs.existsSync(path) ? JSON.parse(fs.readFileSync(path, 'utf8')) : null;
+            const coverage = readJson('nr-app/coverage/coverage-summary.json')?.total;
+            const tests = readJson('nr-app/coverage/test-results.json');
+            const passed = process.env.NR_APP_TEST_OUTCOME === 'success';
+            const percent = metric =>
+              typeof coverage?.[metric]?.pct === 'number'
+                ? `${coverage[metric].pct.toFixed(2)}%`
+                : 'n/a';
+            const coverageIndicator = metric => {
+              const value = coverage?.[metric]?.pct;
+              if (typeof value !== 'number') return '🔴';
+              return value === 100 ? '🟢' : '🟡';
+            };
+            const result = [
+              `Tests       ${passed ? '🟢' : '🔴'} ${tests ? `${tests.numPassedTests}/${tests.numTotalTests}` : 'n/a'}`,
+              `Statements  ${coverageIndicator('statements')} ${percent('statements')}`,
+              `Branches    ${coverageIndicator('branches')} ${percent('branches')}`,
+              `Functions   ${coverageIndicator('functions')} ${percent('functions')}`,
+              `Lines       ${coverageIndicator('lines')} ${percent('lines')}`,
+            ].join('\n');
+            const recorded = new Date().toISOString().slice(0, 16).replace('T', ' ');
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const e2eSection = [
+              e2eStart,
+              e2eEnd,
+            ].join('\n');
+            let body = [
+              marker,
+              '## nr-app test overview',
+              '',
+              `Status: **${passed ? 'Passing' : 'Needs attention'}**`,
+              '',
+              '<table>',
+              '<thead><tr><th>Suite</th><th>Status</th><th>Recorded</th><th>Result</th><th>Report</th></tr></thead>',
+              '<tbody>',
+              `<tr><td>Jest + RNTL</td><td>${passed ? '✓' : '✗ FAILED'}</td><td>${recorded} UTC</td><td><pre>${result}</pre></td><td><a href="${runUrl}"><code>nr-app-coverage-${context.runId}</code></a></td></tr>`,
+              '</tbody>',
+              '</table>',
+              '',
+              e2eSection,
+              '',
+              `Coverage thresholds: statements 61%, branches 51%, functions 55%, lines 62%. [Workflow run](${runUrl}).`,
+            ].join('\n');
+
+            core.summary.addRaw(body).write();
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find(comment =>
+              comment.user.type === 'Bot' && comment.body?.includes(marker)
+            );
+            const e2ePattern = new RegExp(`${e2eStart}[\\s\\S]*?${e2eEnd}`);
+            const existingE2E = existing?.body?.match(e2ePattern)?.[0];
+            if (existingE2E) {
+              body = body.replace(e2ePattern, existingE2E);
+              if (existingE2E.includes('✗ FAILED')) {
+                body = body.replace(
+                  /Status: \*\*[^*]+\*\*/,
+                  'Status: **Needs attention**',
+                );
+              }
+            }
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Require nr-app tests
+        if: steps.nr-app-tests.outcome != 'success'
+        run: exit 1

--- a/nr-app/.gitignore
+++ b/nr-app/.gitignore
@@ -11,6 +11,7 @@ npm-debug.*
 *.mobileprovision
 *.orig.*
 web-build/
+coverage/
 *.apk
 *.aab
 *.ipa

--- a/nr-app/app/(main)/(map)/list.test.tsx
+++ b/nr-app/app/(main)/(map)/list.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent } from "@testing-library/react-native";
+
+import ListScreen from "./list";
+import { renderWithProviders } from "@/test/test-utils";
+
+describe("ListScreen", () => {
+  it("switches between feed, signals, and events empty states", () => {
+    const { getByText } = renderWithProviders(<ListScreen />);
+
+    expect(getByText("Discover")).toBeTruthy();
+    expect(getByText("No notes yet")).toBeTruthy();
+
+    fireEvent.press(getByText("Signals"));
+    expect(getByText("No active signals")).toBeTruthy();
+
+    fireEvent.press(getByText("Events"));
+    expect(getByText("No events yet")).toBeTruthy();
+
+    fireEvent.press(getByText("Feed"));
+    expect(getByText("No notes yet")).toBeTruthy();
+  });
+});

--- a/nr-app/app/index.test.tsx
+++ b/nr-app/app/index.test.tsx
@@ -1,0 +1,63 @@
+import { Redirect } from "expo-router";
+import { waitFor, screen } from "@testing-library/react-native";
+
+import IndexRoute from "./index";
+import { ROUTES } from "@/constants/routes";
+import { renderWithProviders } from "@/test/test-utils";
+
+const mockRedirect = Redirect as jest.Mock;
+
+describe("IndexRoute", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows a loading state while settings are hydrating", () => {
+    renderWithProviders(<IndexRoute />, {
+      preloadedState: {
+        settings: {
+          isDataLoaded: false,
+        },
+      },
+    });
+
+    expect(screen.UNSAFE_getByType("ActivityIndicator")).toBeTruthy();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("sends first-time users to the welcome screen", async () => {
+    renderWithProviders(<IndexRoute />, {
+      preloadedState: {
+        settings: {
+          isDataLoaded: true,
+          hasBeenOpenedBefore: false,
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(mockRedirect).toHaveBeenCalledWith(
+        { href: ROUTES.WELCOME },
+        undefined,
+      );
+    });
+  });
+
+  it("sends returning users without identity to onboarding", async () => {
+    renderWithProviders(<IndexRoute />, {
+      preloadedState: {
+        settings: {
+          isDataLoaded: true,
+          hasBeenOpenedBefore: true,
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(mockRedirect).toHaveBeenCalledWith(
+        { href: ROUTES.ONBOARDING },
+        undefined,
+      );
+    });
+  });
+});

--- a/nr-app/app/onboarding/trustroots.tsx
+++ b/nr-app/app/onboarding/trustroots.tsx
@@ -1,7 +1,7 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
 import { AlertTriangleIcon, MailCheckIcon } from "lucide-react-native";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import { TextInput, View } from "react-native";
 
 import { Button } from "@/components/ui/button";
@@ -31,6 +31,29 @@ type TrustrootsScreenState =
 
 const AUTHENTICATION_FAILURE_MESSAGE = "failed to authenticate you. try again";
 
+function getInitialStatusMessage({
+  errorParam,
+  pendingProfileUsername,
+  pendingUsername,
+}: {
+  errorParam?: string;
+  pendingProfileUsername: string | null;
+  pendingUsername: string | null;
+}) {
+  if (errorParam === "auth") return AUTHENTICATION_FAILURE_MESSAGE;
+  if (errorParam === "missing-token") {
+    return "Verification link is missing a token. Try again.";
+  }
+  if (errorParam === "start-in-app") {
+    return "Start verification in the app before opening the email link.";
+  }
+  if (pendingProfileUsername) {
+    return "Your Trustroots account was authenticated. Retry the profile publish to finish setup.";
+  }
+  if (pendingUsername) return "Enter the six-digit code from your email.";
+  return null;
+}
+
 function getRequestErrorMessage(error: unknown): string {
   if (error instanceof NrBridgeError) {
     if (error.code === "config") {
@@ -56,44 +79,25 @@ export default function OnboardingTrustrootsScreen() {
     settingsSelectors.selectPendingTrustrootsProfileUsername,
   );
 
-  const [screenState, setScreenState] = useState<TrustrootsScreenState>("idle");
-  const [usernameInput, setUsernameInput] = useState("");
+  const [screenState, setScreenState] = useState<TrustrootsScreenState>(
+    pendingTrustrootsProfileUsername
+      ? "profile-retry"
+      : pendingTrustrootsUsername
+        ? "code-entry"
+        : "idle",
+  );
+  const [usernameInput, setUsernameInput] = useState(
+    pendingTrustrootsProfileUsername ?? pendingTrustrootsUsername ?? "",
+  );
   const [code, setCode] = useState("");
   const [fieldError, setFieldError] = useState<string | null>(null);
-  const [statusMessage, setStatusMessage] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (errorParam === "auth") {
-      setStatusMessage(AUTHENTICATION_FAILURE_MESSAGE);
-    } else if (errorParam === "missing-token") {
-      setStatusMessage("Verification link is missing a token. Try again.");
-    } else if (errorParam === "start-in-app") {
-      setStatusMessage(
-        "Start verification in the app before opening the email link.",
-      );
-    }
-  }, [errorParam]);
-
-  useEffect(() => {
-    if (pendingTrustrootsProfileUsername) {
-      setUsernameInput(pendingTrustrootsProfileUsername);
-      setScreenState("profile-retry");
-      setStatusMessage(
-        "Your Trustroots account was authenticated. Retry the profile publish to finish setup.",
-      );
-      return;
-    }
-
-    if (pendingTrustrootsUsername && screenState === "idle") {
-      setUsernameInput(pendingTrustrootsUsername);
-      setScreenState("code-entry");
-      setStatusMessage("Enter the six-digit code from your email.");
-    }
-  }, [
-    pendingTrustrootsProfileUsername,
-    pendingTrustrootsUsername,
-    screenState,
-  ]);
+  const [statusMessage, setStatusMessage] = useState<string | null>(() =>
+    getInitialStatusMessage({
+      errorParam,
+      pendingProfileUsername: pendingTrustrootsProfileUsername,
+      pendingUsername: pendingTrustrootsUsername,
+    }),
+  );
 
   const resetToUsernameEntry = useCallback(
     (message?: string) => {

--- a/nr-app/app/welcome.test.tsx
+++ b/nr-app/app/welcome.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render } from "@testing-library/react-native";
+import { useRouter } from "expo-router";
+
+import WelcomeScreen from "./welcome";
+
+const mockUseRouter = useRouter as jest.Mock;
+
+describe("WelcomeScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("moves users into onboarding from the welcome screen", () => {
+    const replace = jest.fn();
+    mockUseRouter.mockReturnValue({
+      push: jest.fn(),
+      replace,
+      back: jest.fn(),
+    });
+
+    const { getByText } = render(<WelcomeScreen />);
+
+    expect(getByText("Welcome to Nostroots")).toBeTruthy();
+    fireEvent.press(getByText("Get Started"));
+
+    expect(replace).toHaveBeenCalledWith("/onboarding");
+  });
+});

--- a/nr-app/jest.config.js
+++ b/nr-app/jest.config.js
@@ -1,0 +1,42 @@
+const transformIgnorePatterns = [
+  "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|nativewind|react-redux|@rn-primitives/.*|@trustroots/nr-common|@reduxjs/toolkit|immer|redux-persist|redux-devtools-expo-dev-plugin|nostr-tools|@noble/.*|@scure/.*)",
+];
+
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: "jest-expo",
+  setupFilesAfterEnv: ["./jest.setup.ts"],
+  transformIgnorePatterns,
+  moduleNameMapper: {
+    "^@noble/hashes/utils$": "<rootDir>/../node_modules/@noble/hashes/utils.js",
+  },
+  collectCoverageFrom: [
+    "app/**/*.{ts,tsx}",
+    "src/**/*.{ts,tsx}",
+    "!**/*.test.{ts,tsx,js,jsx}",
+    "!**/*.spec.{ts,tsx,js,jsx}",
+    "!**/*.d.ts",
+    "!expo-env.d.ts",
+    "!nativewind-env.d.ts",
+    "!app/+html.tsx",
+    "!app/+not-found.tsx",
+    "!app/e2e/**",
+    "!src/test/**",
+    "!src/reactotron.config.ts",
+    "!src/index.ts",
+    "!src/components/ui/native-only-animated-view.tsx",
+    "!src/components/Map.web.tsx",
+  ],
+  coverageDirectory: "coverage",
+  coverageReporters: ["text-summary", "lcov", "json-summary"],
+  clearMocks: true,
+  restoreMocks: true,
+  coverageThreshold: {
+    global: {
+      statements: 61,
+      branches: 51,
+      functions: 55,
+      lines: 62,
+    },
+  },
+};

--- a/nr-app/jest.setup.ts
+++ b/nr-app/jest.setup.ts
@@ -1,16 +1,21 @@
 // Jest setup - mocks for native modules
 
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
 // Mock expo-notifications
 jest.mock("expo-notifications", () => ({
+  AndroidImportance: { MAX: "max" },
   setNotificationHandler: jest.fn(),
   addNotificationReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
   addNotificationResponseReceivedListener: jest.fn(() => ({
     remove: jest.fn(),
   })),
   getExpoPushTokenAsync: jest.fn(),
+  getLastNotificationResponse: jest.fn(() => null),
   getPermissionsAsync: jest.fn(),
   requestPermissionsAsync: jest.fn(),
   scheduleNotificationAsync: jest.fn(),
+  setNotificationChannelAsync: jest.fn(),
   addPushTokenListener: jest.fn(() => ({ remove: jest.fn() })),
 }));
 
@@ -19,35 +24,19 @@ jest.mock("@react-native-async-storage/async-storage", () =>
   require("@react-native-async-storage/async-storage/jest/async-storage-mock"),
 );
 
-// Mock expo-router
-jest.mock("expo-router", () => ({
-  Redirect: jest.fn(() => null),
-  Slot: ({ children }: { children?: unknown }) => children,
-  Stack: {
-    Screen: () => null,
-  },
-  router: {
-    push: jest.fn(),
-    replace: jest.fn(),
-    back: jest.fn(),
-  },
-  usePathname: jest.fn(() => "/"),
-  useLocalSearchParams: jest.fn(() => ({})),
-  useFocusEffect: (callback: () => void | (() => void)) => {
-    const React = require("react");
-    React.useEffect(callback, [callback]);
-  },
-  useRouter: jest.fn(() => ({
-    push: jest.fn(),
-    replace: jest.fn(),
-    back: jest.fn(),
-  })),
-}));
+jest.mock("expo-router", () =>
+  require("./src/test/router").createExpoRouterMock(),
+);
 
 // Mock react-native-maps
 jest.mock("react-native-maps", () => ({
   __esModule: true,
   default: "MapView",
+  Callout: "Callout",
+  Circle: "Circle",
+  Marker: "Marker",
+  Polygon: "Polygon",
+  Polyline: "Polyline",
 }));
 
 jest.mock("@expo/vector-icons/Ionicons", () => ({
@@ -64,22 +53,33 @@ jest.mock("@rn-primitives/slot", () => ({
   Text: "Text",
 }));
 
-jest.mock("expo-secure-store", () => {
-  const store = new Map<string, string>();
+jest.mock("expo-secure-store", () =>
+  require("./src/test/secureStoreMock").createSecureStoreMock(),
+);
 
-  return {
-    AFTER_FIRST_UNLOCK: 1,
-    __reset: () => store.clear(),
-    __store: store,
-    getItemAsync: jest.fn(async (key: string) => store.get(key) ?? null),
-    setItemAsync: jest.fn(async (key: string, value: string) => {
-      store.set(key, value);
-    }),
-    deleteItemAsync: jest.fn(async (key: string) => {
-      store.delete(key);
-    }),
-  };
-});
+jest.mock("expo-device", () =>
+  require("./src/test/expoDeviceMock").createExpoDeviceMock(),
+);
+
+jest.mock("expo-constants", () => ({
+  __esModule: true,
+  default: {
+    easConfig: { projectId: "test-project-id" },
+    expoConfig: { extra: { eas: { projectId: "test-project-id" } } },
+  },
+}));
+
+jest.mock("expo-location", () => ({
+  Accuracy: { Balanced: 3, High: 4 },
+  getCurrentPositionAsync: jest.fn(async () => ({
+    coords: { latitude: 52.52, longitude: 13.405 },
+    timestamp: 0,
+  })),
+  getForegroundPermissionsAsync: jest.fn(async () => ({ status: "granted" })),
+  requestForegroundPermissionsAsync: jest.fn(async () => ({
+    status: "granted",
+  })),
+}));
 
 jest.mock("expo-web-browser", () => ({
   openBrowserAsync: jest.fn(async () => ({ type: "opened" })),
@@ -120,8 +120,29 @@ jest.mock("@maplibre/maplibre-react-native", () => ({
   UserLocation: "UserLocation",
 }));
 
+jest.mock("react-native-reanimated", () => {
+  const { View } = require("react-native");
+  return {
+    __esModule: true,
+    default: { View },
+    FadeIn: { delay: jest.fn(() => ({})), duration: jest.fn(() => ({})) },
+    FadeOut: { duration: jest.fn(() => ({})) },
+    useAnimatedStyle: jest.fn(() => ({})),
+    useSharedValue: jest.fn((value) => ({ value })),
+  };
+});
+
+jest.mock("react-native-worklets", () => ({}));
+
 // Mock redux-devtools-expo-dev-plugin
 jest.mock("redux-devtools-expo-dev-plugin", () => ({
   __esModule: true,
   default: () => (next: unknown) => next,
 }));
+
+beforeEach(async () => {
+  require("./src/test/router").resetRouterMock();
+  require("./src/test/secureStoreMock").resetSecureStoreMock();
+  require("./src/test/expoDeviceMock").resetExpoDeviceMock();
+  await AsyncStorage.clear();
+});

--- a/nr-app/package.json
+++ b/nr-app/package.json
@@ -8,9 +8,12 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "test": "jest",
-    "test:watch": "jest --watchAll",
     "test:e2e": "maestro test .maestro/flows",
+    "test": "jest --watchman=false",
+    "test:ci": "jest --ci --coverage --runInBand --watchman=false --json --outputFile=coverage/test-results.json",
+    "test:coverage": "jest --coverage --watchman=false",
+    "test:watch": "jest --watch --watchman=false",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "prepare": "cd .. && husky nr-app/.husky",
     "build:android-development": "eas build --platform android --profile development --non-interactive",
@@ -21,18 +24,6 @@
     "build:ios-production": "eas build --platform ios --profile production --non-interactive --auto-submit"
   },
   "pkgx": "facebook.com/watchman",
-  "jest": {
-    "preset": "jest-expo",
-    "setupFilesAfterEnv": [
-      "./jest.setup.ts"
-    ],
-    "moduleNameMapper": {
-      "^@noble/hashes/utils$": "<rootDir>/../node_modules/@noble/hashes/utils.js"
-    },
-    "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|nativewind|@trustroots/nr-common|@reduxjs/toolkit|immer|redux-persist|redux-devtools-expo-dev-plugin|nostr-tools|@noble/.*|@scure/.*)"
-    ]
-  },
   "dependencies": {
     "@expo/dom-webview": "^56.0.5",
     "@expo/vector-icons": "^15.1.1",

--- a/nr-app/src/common/utils.test.ts
+++ b/nr-app/src/common/utils.test.ts
@@ -1,0 +1,55 @@
+import { MAP_LAYERS } from "@trustroots/nr-common";
+import {
+  addOpenLocationCodePrefixToFilter,
+  filterForMapLayerConfig,
+  filterForMapLayerConfigForPlusCodePrefixes,
+  getTrustrootsMapFilter,
+  openLocationCodePrefixFilter,
+  trustrootsMapFilterForPlusCodePrefixes,
+} from "./utils";
+
+describe("common/utils", () => {
+  it("creates the Trustroots map filter", () => {
+    expect(getTrustrootsMapFilter()).toMatchObject({
+      kinds: [30398],
+    });
+  });
+
+  it("creates plus-code prefix filters", () => {
+    expect(openLocationCodePrefixFilter(["9F4G"])).toEqual({
+      "#L": ["open-location-code-prefix"],
+      "#l": ["9F4G"],
+    });
+  });
+
+  it("combines map filters with plus-code prefixes", () => {
+    expect(addOpenLocationCodePrefixToFilter({ kinds: [1] }, ["9F4G"])).toEqual(
+      {
+        "#L": ["open-location-code-prefix"],
+        "#l": ["9F4G"],
+        kinds: [1],
+      },
+    );
+  });
+
+  it("builds Trustroots map filters for plus-code prefixes", () => {
+    expect(trustrootsMapFilterForPlusCodePrefixes(["9F4G"])).toMatchObject({
+      "#l": ["9F4G"],
+      kinds: [30398],
+    });
+  });
+
+  it("builds layer filters", () => {
+    const layer = MAP_LAYERS.trustroots;
+
+    expect(filterForMapLayerConfig(layer)).toMatchObject({
+      kinds: [layer.kind],
+    });
+    expect(
+      filterForMapLayerConfigForPlusCodePrefixes(layer, ["9F4G"]),
+    ).toMatchObject({
+      "#l": ["9F4G"],
+      kinds: [layer.kind],
+    });
+  });
+});

--- a/nr-app/src/components/AddNoteForm.test.tsx
+++ b/nr-app/src/components/AddNoteForm.test.tsx
@@ -1,0 +1,201 @@
+import { act, fireEvent, waitFor } from "@testing-library/react-native";
+import Toast from "react-native-root-toast";
+
+import { trackEvent } from "@/services/analytics.service";
+import { createTestStore, renderWithProviders } from "@/test/test-utils";
+import AddNoteForm from "./AddNoteForm";
+
+jest.mock("@react-native-community/datetimepicker", () => ({
+  __esModule: true,
+  default: "DateTimePicker",
+}));
+
+jest.mock("@/services/analytics.service", () => ({
+  trackEvent: jest.fn(),
+}));
+
+const selectedLocationState = {
+  map: {
+    selectedPlusCode: "9F4MGCG4+5X",
+  },
+};
+
+function getPublishedTemplate(dispatchSpy: jest.SpyInstance) {
+  const action = dispatchSpy.mock.calls.at(-1)?.[0];
+  return action.payload.eventTemplate;
+}
+
+describe("AddNoteForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it("explains why a note cannot be sent without a selected location", () => {
+    const { getByPlaceholderText } = renderWithProviders(<AddNoteForm />);
+    const input = getByPlaceholderText("Share a tip or say hi...");
+
+    fireEvent.changeText(input, "Tea at my place");
+    fireEvent(input, "submitEditing");
+
+    expect(Toast.show).toHaveBeenCalledWith(
+      "Error: No plus code selected. #Rjbe0s",
+      expect.objectContaining({ duration: Toast.durations.LONG }),
+    );
+  });
+
+  it("rejects content that is too short after trimming", () => {
+    const { getByPlaceholderText, store } = renderWithProviders(
+      <AddNoteForm />,
+      { preloadedState: selectedLocationState },
+    );
+    const dispatchSpy = jest.spyOn(store, "dispatch");
+    const input = getByPlaceholderText("Share a tip or say hi...");
+
+    fireEvent.changeText(input, " x ");
+    fireEvent(input, "submitEditing");
+
+    expect(Toast.show).toHaveBeenCalledWith(
+      "Note must be at least 3 characters long",
+      expect.objectContaining({ duration: Toast.durations.LONG }),
+    );
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+
+  it("publishes trimmed content with the selected duration", async () => {
+    const onSent = jest.fn();
+    const store = createTestStore(selectedLocationState);
+    const dispatchSpy = jest.spyOn(store, "dispatch");
+    const { getByPlaceholderText, getByRole, getByText, queryByText } =
+      renderWithProviders(<AddNoteForm onSent={onSent} />, { store });
+
+    fireEvent.press(getByText("Today"));
+    fireEvent.changeText(
+      getByPlaceholderText("Share a tip or say hi..."),
+      "  Hosting tea in Berlin  ",
+    );
+    fireEvent.press(getByRole("button"));
+
+    expect(onSent).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(queryByText("sending...")).toBeNull());
+
+    const template = getPublishedTemplate(dispatchSpy);
+    expect(template).toEqual(
+      expect.objectContaining({
+        content: "Hosting tea in Berlin",
+        kind: 30397,
+        created_at: 1_800_000_000,
+      }),
+    );
+    expect(template.tags).toContainEqual(["expiration", "1800086400"]);
+    expect(trackEvent).toHaveBeenCalledWith("note_published", {
+      intent: "none",
+      outcome: "success",
+    });
+  });
+
+  it("publishes a signal with its intent and exits signal mode", async () => {
+    const onSignalSent = jest.fn();
+    const store = createTestStore(selectedLocationState);
+    const dispatchSpy = jest.spyOn(store, "dispatch");
+    const { getByPlaceholderText, getByRole, getByText } = renderWithProviders(
+      <AddNoteForm signalMode onSignalSent={onSignalSent} />,
+      { store },
+    );
+
+    fireEvent.press(getByText("☕"));
+    fireEvent.changeText(
+      getByPlaceholderText("Anyone down for coffee?"),
+      "Coffee near the park",
+    );
+    fireEvent.press(getByRole("button"));
+
+    await waitFor(() => expect(onSignalSent).toHaveBeenCalledTimes(1));
+    const template = getPublishedTemplate(dispatchSpy);
+    expect(template.tags).toEqual(
+      expect.arrayContaining([
+        ["t", "signal"],
+        ["t", "coffee"],
+      ]),
+    );
+    expect(trackEvent).toHaveBeenCalledWith("note_published", {
+      intent: "coffee",
+      outcome: "success",
+    });
+  });
+
+  it("shows failed optimistic notes and retries them", async () => {
+    const store = createTestStore(selectedLocationState);
+    const dispatchSpy = jest
+      .spyOn(store, "dispatch")
+      .mockRejectedValueOnce(new Error("relay unavailable"))
+      .mockResolvedValueOnce(undefined);
+    const { getByLabelText, getByPlaceholderText, getByRole, getByText } =
+      renderWithProviders(<AddNoteForm />, { store });
+
+    fireEvent.changeText(
+      getByPlaceholderText("Share a tip or say hi..."),
+      "Meet at the station",
+    );
+    fireEvent.press(getByRole("button"));
+
+    await waitFor(() => expect(getByText("tap to retry")).toBeTruthy());
+    expect(trackEvent).toHaveBeenCalledWith("note_published", {
+      intent: "none",
+      outcome: "failure",
+    });
+
+    fireEvent.press(getByLabelText("Retry publishing note"));
+
+    await waitFor(() => {
+      expect(trackEvent).toHaveBeenCalledWith("note_publish_retried", {
+        outcome: "success",
+      });
+    });
+    expect(dispatchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks a publish as retryable when the relay response times out", async () => {
+    jest.useFakeTimers();
+    const store = createTestStore(selectedLocationState);
+    jest
+      .spyOn(store, "dispatch")
+      .mockImplementation(() => new Promise(() => undefined));
+    const { getByPlaceholderText, getByRole, getByText } = renderWithProviders(
+      <AddNoteForm />,
+      { store },
+    );
+
+    fireEvent.changeText(
+      getByPlaceholderText("Share a tip or say hi..."),
+      "Waiting for relays",
+    );
+    fireEvent.press(getByRole("button"));
+    expect(getByText("sending...")).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(10_000);
+    });
+
+    expect(getByText("tap to retry")).toBeTruthy();
+  });
+
+  it("shows the remaining character count near the content limit", () => {
+    const { getByPlaceholderText, getByText } = renderWithProviders(
+      <AddNoteForm />,
+      { preloadedState: selectedLocationState },
+    );
+
+    fireEvent.changeText(
+      getByPlaceholderText("Share a tip or say hi..."),
+      "a".repeat(3_801),
+    );
+
+    expect(getByText("199 characters left")).toBeTruthy();
+  });
+});

--- a/nr-app/src/components/AddNoteForm.tsx
+++ b/nr-app/src/components/AddNoteForm.tsx
@@ -125,15 +125,15 @@ export default function AddNoteForm({
     setOptimisticNotes((prev) => [...prev, optimisticNote]);
     onSent?.();
 
-    try {
-      const timeout = setTimeout(() => {
-        setOptimisticNotes((prev) =>
-          prev.map((n) =>
-            n.id === optimisticId ? { ...n, status: "failed" as const } : n,
-          ),
-        );
-      }, 10000);
+    const timeout = setTimeout(() => {
+      setOptimisticNotes((prev) =>
+        prev.map((n) =>
+          n.id === optimisticId ? { ...n, status: "failed" as const } : n,
+        ),
+      );
+    }, 10000);
 
+    try {
       await dispatch(
         publishNotePromiseAction(
           trimmedContent,
@@ -161,6 +161,7 @@ export default function AddNoteForm({
         intent: effectiveIntent ?? "none",
         outcome: "failure",
       });
+      clearTimeout(timeout);
       // Mark as failed
       setOptimisticNotes((prev) =>
         prev.map((n) =>
@@ -236,7 +237,11 @@ export default function AddNoteForm({
                 sending...
               </Text>
             ) : (
-              <Pressable onPress={() => handleRetry(note)}>
+              <Pressable
+                accessibilityLabel="Retry publishing note"
+                accessibilityRole="button"
+                onPress={() => handleRetry(note)}
+              >
                 <Text className="text-[11px] text-destructive font-semibold">
                   tap to retry
                 </Text>

--- a/nr-app/src/components/KeyInput.test.tsx
+++ b/nr-app/src/components/KeyInput.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
+import * as Clipboard from "expo-clipboard";
+
+import { renderWithProviders } from "@/test/render";
+import { KeyInput } from "./KeyInput";
+
+describe("KeyInput", () => {
+  it("pastes clipboard text", async () => {
+    const onChangeText = jest.fn();
+    (Clipboard.getStringAsync as jest.Mock).mockResolvedValue("pasted secret");
+
+    renderWithProviders(
+      <KeyInput value="" onChangeText={onChangeText} showPasteButton />,
+    );
+
+    fireEvent.press(screen.getByText("Paste"));
+
+    await waitFor(() => {
+      expect(onChangeText).toHaveBeenCalledWith("pasted secret");
+    });
+  });
+
+  it("copies current value", async () => {
+    renderWithProviders(
+      <KeyInput value="secret" onChangeText={jest.fn()} showCopyButton />,
+    );
+
+    fireEvent.press(screen.getByText("Copy"));
+
+    await waitFor(() => {
+      expect(Clipboard.setStringAsync).toHaveBeenCalledWith("secret");
+    });
+  });
+
+  it("regenerates generated mnemonic values", () => {
+    const onChangeText = jest.fn();
+    const onRegenerate = jest.fn();
+
+    renderWithProviders(
+      <KeyInput
+        value="existing"
+        onChangeText={onChangeText}
+        generateMode
+        showRegenerateButton
+        onRegenerate={onRegenerate}
+      />,
+    );
+
+    fireEvent.press(screen.getByText("Regenerate"));
+
+    expect(onChangeText).toHaveBeenCalledWith(expect.any(String));
+    expect(onRegenerate).toHaveBeenCalledWith(expect.any(String));
+  });
+});

--- a/nr-app/src/components/MapAddNoteModal.test.tsx
+++ b/nr-app/src/components/MapAddNoteModal.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, waitFor } from "@testing-library/react-native";
+import Toast from "react-native-root-toast";
+
+import MapAddNoteModal from "./MapAddNoteModal";
+import { renderWithProviders } from "@/test/test-utils";
+
+const openModalState = {
+  map: {
+    isAddNoteModalOpen: true,
+    selectedLatLng: {
+      latitude: 52.52,
+      longitude: 13.405,
+    },
+  },
+};
+
+describe("MapAddNoteModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not publish an empty note", () => {
+    const { getByText, store } = renderWithProviders(<MapAddNoteModal />, {
+      preloadedState: openModalState,
+    });
+    const dispatchSpy = jest.spyOn(store, "dispatch");
+
+    fireEvent.press(getByText("Add Note"));
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "publish/eventTemplate/request" }),
+    );
+  });
+
+  it("dispatches a map note publish request for valid content", async () => {
+    const { getByPlaceholderText, getByText, store } = renderWithProviders(
+      <MapAddNoteModal />,
+      {
+        preloadedState: openModalState,
+      },
+    );
+    const dispatchSpy = jest.spyOn(store, "dispatch");
+
+    fireEvent.changeText(
+      getByPlaceholderText("Enter your note"),
+      "Hosting tea in Berlin",
+    );
+    fireEvent.press(getByText("Add Note"));
+
+    await waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "publish/eventTemplate/request",
+          payload: {
+            eventTemplate: expect.objectContaining({
+              content: "Hosting tea in Berlin",
+              kind: 30397,
+            }),
+          },
+        }),
+      );
+      expect(Toast.show).toHaveBeenCalledWith(
+        "Note added successfully",
+        expect.objectContaining({ duration: Toast.durations.LONG }),
+      );
+    });
+  });
+});

--- a/nr-app/src/components/MapLayerSelector.test.tsx
+++ b/nr-app/src/components/MapLayerSelector.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, screen } from "@testing-library/react-native";
+
+import { settingsSlice } from "@/redux/slices/settings.slice";
+import { renderWithProviders } from "@/test/render";
+import MapLayerSelector from "./MapLayerSelector";
+
+jest.mock("nativewind", () => ({
+  cssInterop: jest.fn(),
+  useColorScheme: () => ({ colorScheme: "light" }),
+}));
+
+describe("MapLayerSelector", () => {
+  it("selects a layer when experimental layers are acknowledged", () => {
+    const { store } = renderWithProviders(<MapLayerSelector />, {
+      preloadedState: {
+        settings: {
+          ...settingsSlice.getInitialState(),
+          hasAcknowledgedExperimentalLayers: true,
+        },
+      },
+    });
+
+    fireEvent.press(screen.getByText("Trustroots"));
+    fireEvent.press(screen.getByText("Hitchwiki"));
+
+    expect(store.getState().map.selectedLayer).toBe("hitchwiki");
+  });
+});

--- a/nr-app/src/components/NotesList.test.tsx
+++ b/nr-app/src/components/NotesList.test.tsx
@@ -1,0 +1,60 @@
+import {
+  MAP_NOTE_REPOST_KIND,
+  NOSTROOTS_VALIDATION_PUBKEY,
+  OPEN_LOCATION_CODE_LABEL_NAMESPACE,
+} from "@trustroots/nr-common";
+
+import {
+  eventsAdapter,
+  type EventWithMetadata,
+} from "@/redux/slices/events.slice";
+import { renderWithProviders } from "@/test/render";
+import { screen } from "@testing-library/react-native";
+import NotesList from "./NotesList";
+
+function noteEvent(
+  id: string,
+  plusCode: string,
+  content: string,
+): EventWithMetadata {
+  return {
+    event: {
+      content,
+      created_at: 1,
+      id,
+      kind: MAP_NOTE_REPOST_KIND,
+      pubkey: NOSTROOTS_VALIDATION_PUBKEY,
+      sig: "2".repeat(128),
+      tags: [
+        ["L", OPEN_LOCATION_CODE_LABEL_NAMESPACE],
+        ["l", plusCode, OPEN_LOCATION_CODE_LABEL_NAMESPACE],
+      ],
+    },
+    metadata: {
+      seenOnRelays: ["wss://relay.example"],
+    },
+  };
+}
+
+describe("NotesList", () => {
+  it("renders empty exact and child counts", () => {
+    renderWithProviders(<NotesList plusCode="9F4G0000+" />);
+
+    expect(screen.getByText("No messages yet. Be the first!")).toBeTruthy();
+  });
+
+  it("renders exact matching notes", () => {
+    const exact = noteEvent("0".repeat(64), "9F4G0000+", "Exact note");
+    const events = eventsAdapter.setAll(eventsAdapter.getInitialState(), [
+      exact,
+    ]);
+
+    renderWithProviders(<NotesList plusCode="9F4G0000+" />, {
+      preloadedState: {
+        events,
+      },
+    });
+
+    expect(screen.getByText("Exact note")).toBeTruthy();
+  });
+});

--- a/nr-app/src/components/NotificationSubscription.test.tsx
+++ b/nr-app/src/components/NotificationSubscription.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, waitFor } from "@testing-library/react-native";
+import Toast from "react-native-root-toast";
+
+import NotificationSubscription from "./NotificationSubscription";
+import {
+  subscribeToPlusCode,
+  unsubscribeFromPlusCode,
+} from "@/redux/actions/notifications.actions";
+import { filterForPlusCode } from "@/utils/notifications.utils";
+import { createTestStore, renderWithProviders } from "@/test/test-utils";
+import { TEST_PLUS_CODE } from "@/test/fixtures";
+
+describe("NotificationSubscription", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("dispatches a subscribe request for the selected plus code", async () => {
+    const store = createTestStore({
+      map: {
+        selectedPlusCode: TEST_PLUS_CODE,
+      },
+    });
+    const dispatchSpy = jest.spyOn(store, "dispatch");
+    const { getAllByText } = renderWithProviders(<NotificationSubscription />, {
+      store,
+    });
+
+    fireEvent.press(getAllByText("Subscribe")[1]);
+
+    await waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: subscribeToPlusCode(TEST_PLUS_CODE).type,
+          payload: { plusCode: TEST_PLUS_CODE },
+        }),
+      );
+      expect(Toast.show).toHaveBeenCalledWith(
+        "Successfully subscribed",
+        expect.objectContaining({ duration: Toast.durations.LONG }),
+      );
+    });
+  });
+
+  it("shows unsubscribe for an exact subscription and dispatches removal", async () => {
+    const store = createTestStore({
+      map: {
+        selectedPlusCode: TEST_PLUS_CODE,
+      },
+      notifications: {
+        filters: [{ filter: filterForPlusCode(TEST_PLUS_CODE) }],
+      },
+    });
+    const dispatchSpy = jest.spyOn(store, "dispatch");
+    const { getByText } = renderWithProviders(<NotificationSubscription />, {
+      store,
+    });
+
+    expect(
+      getByText("You are subscribed to notifications for this plus code."),
+    ).toBeTruthy();
+
+    fireEvent.press(getByText("Unsubscribe"));
+
+    await waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: unsubscribeFromPlusCode(TEST_PLUS_CODE).type,
+          payload: { plusCode: TEST_PLUS_CODE },
+        }),
+      );
+      expect(Toast.show).toHaveBeenCalledWith(
+        "Successfully unsubscribed",
+        expect.objectContaining({ duration: Toast.durations.LONG }),
+      );
+    });
+  });
+});

--- a/nr-app/src/components/SignalMiniCard.tsx
+++ b/nr-app/src/components/SignalMiniCard.tsx
@@ -130,9 +130,7 @@ export default function SignalMiniCard({
           {typeof username !== "undefined" && (
             <Pressable
               onPress={() =>
-                Linking.openURL(
-                  `https://trustroots.org/messages/${username}`,
-                )
+                Linking.openURL(`https://trustroots.org/messages/${username}`)
               }
               className="mt-3 rounded-lg bg-primary/10 py-2 px-3"
             >

--- a/nr-app/src/hooks/useKeyImport.test.ts
+++ b/nr-app/src/hooks/useKeyImport.test.ts
@@ -1,0 +1,94 @@
+import { act, renderHook } from "@testing-library/react-native";
+import { nip19 } from "nostr-tools";
+import { useAppDispatch } from "@/redux/hooks";
+import { setPrivateKeyPromiseAction } from "@/redux/sagas/keystore.saga";
+import { useKeyImport } from "./useKeyImport";
+
+jest.mock("@/redux/hooks", () => ({
+  useAppDispatch: jest.fn(),
+}));
+
+describe("useKeyImport", () => {
+  const dispatch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAppDispatch as jest.Mock).mockReturnValue(dispatch);
+    dispatch.mockResolvedValue(undefined);
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  it("imports a mnemonic after trimming whitespace", async () => {
+    const { result } = renderHook(() => useKeyImport());
+
+    await act(async () => {
+      await expect(
+        result.current.importKey("  one two three four  "),
+      ).resolves.toEqual({ success: true, type: "mnemonic" });
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      setPrivateKeyPromiseAction.request({
+        mnemonic: "one two three four",
+      }),
+    );
+    expect(result.current.isImporting).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("decodes and imports an nsec key", async () => {
+    const privateKey = new Uint8Array(32).fill(7);
+    const nsec = nip19.nsecEncode(privateKey);
+    const { result } = renderHook(() => useKeyImport());
+
+    await act(async () => {
+      await expect(result.current.importKey(nsec)).resolves.toEqual({
+        success: true,
+        type: "nsec",
+      });
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      setPrivateKeyPromiseAction.request({
+        privateKeyHex: "07".repeat(32),
+      }),
+    );
+  });
+
+  it("reports empty and malformed key inputs", async () => {
+    const { result } = renderHook(() => useKeyImport());
+
+    await act(async () => {
+      await expect(result.current.importKey("   ")).resolves.toEqual({
+        success: false,
+        type: null,
+      });
+    });
+    expect(result.current.error).toBe("Please enter a key");
+
+    await act(async () => {
+      await result.current.importKey("nsec-not-valid");
+    });
+    expect(result.current.error).toBe(
+      "That key format does not look right. Check and try again.",
+    );
+  });
+
+  it("reports storage failures and allows clearing the error", async () => {
+    dispatch.mockRejectedValueOnce("storage unavailable");
+    const { result } = renderHook(() => useKeyImport());
+
+    await act(async () => {
+      await expect(result.current.importKey("word list")).resolves.toEqual({
+        success: false,
+        type: null,
+      });
+    });
+    expect(result.current.error).toBe(
+      "We could not save this key. Please check and try again.",
+    );
+
+    act(() => result.current.clearError());
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/nr-app/src/hooks/useUpdateOnForeground.test.ts
+++ b/nr-app/src/hooks/useUpdateOnForeground.test.ts
@@ -1,0 +1,85 @@
+import { act, renderHook } from "@testing-library/react-native";
+import * as Updates from "expo-updates";
+import { AppState } from "react-native";
+import Toast from "react-native-root-toast";
+import { useUpdateOnForeground } from "./useUpdateOnForeground";
+
+jest.mock("expo-updates", () => ({
+  checkForUpdateAsync: jest.fn(),
+  fetchUpdateAsync: jest.fn(),
+  reloadAsync: jest.fn(),
+}));
+
+describe("useUpdateOnForeground", () => {
+  let onChange: (state: string) => Promise<void>;
+  const remove = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest
+      .spyOn(AppState, "addEventListener")
+      .mockImplementation((_event, listener) => {
+        onChange = listener as (state: string) => Promise<void>;
+        return { remove };
+      });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("checks only when the app becomes active", async () => {
+    (Updates.checkForUpdateAsync as jest.Mock).mockResolvedValue({
+      isAvailable: false,
+    });
+    renderHook(() => useUpdateOnForeground());
+
+    await act(async () => onChange("background"));
+    expect(Updates.checkForUpdateAsync).not.toHaveBeenCalled();
+
+    await act(async () => onChange("active"));
+    expect(Updates.checkForUpdateAsync).toHaveBeenCalledTimes(1);
+    expect(Updates.fetchUpdateAsync).not.toHaveBeenCalled();
+  });
+
+  it("downloads an available update and schedules a reload", async () => {
+    (Updates.checkForUpdateAsync as jest.Mock).mockResolvedValue({
+      isAvailable: true,
+    });
+    (Updates.fetchUpdateAsync as jest.Mock).mockResolvedValue(undefined);
+    (Updates.reloadAsync as jest.Mock).mockResolvedValue(undefined);
+    renderHook(() => useUpdateOnForeground());
+
+    await act(async () => onChange("active"));
+    expect(Toast.show).toHaveBeenNthCalledWith(1, "Downloading app update…");
+    expect(Updates.fetchUpdateAsync).toHaveBeenCalledTimes(1);
+    expect(Toast.show).toHaveBeenNthCalledWith(
+      2,
+      "Update downloaded, app will restart in 5 seconds.",
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+      await Promise.resolve();
+    });
+    expect(Updates.reloadAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs update-check failures without throwing", async () => {
+    const error = new Error("offline");
+    (Updates.checkForUpdateAsync as jest.Mock).mockRejectedValue(error);
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    renderHook(() => useUpdateOnForeground());
+
+    await act(async () => onChange("active"));
+    expect(console.warn).toHaveBeenCalledWith("Update check failed:", error);
+  });
+
+  it("removes the app-state listener on unmount", () => {
+    const { unmount } = renderHook(() => useUpdateOnForeground());
+    unmount();
+
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/nr-app/src/nostr/keystore.nostr.test.ts
+++ b/nr-app/src/nostr/keystore.nostr.test.ts
@@ -1,0 +1,111 @@
+import {
+  SECURE_STORE_PRIVATE_KEY_HEX_KEY,
+  SECURE_STORE_PRIVATE_KEY_HEX_MNEMONIC,
+} from "@/constants";
+import {
+  resetSecureStoreMock,
+  seedSecureStoreMock,
+} from "@/test/secureStoreMock";
+import { accountFromSeedWords } from "nip06";
+import {
+  derivePublicKeyHexFromMnemonic,
+  getHasPrivateKeyHexInSecureStorage,
+  getHasPrivateKeyInSecureStorage,
+  getHasPrivateKeyMnemonicInSecureStorage,
+  getPrivateKeyHexFromSecureStorage,
+  getPrivateKeyMnemonicFromSecureStorage,
+  getPublicKeyHexFromSecureStorage,
+  setPrivateKeyInSecureStorage,
+  signEventTemplate,
+} from "./keystore.nostr";
+
+const mnemonic =
+  "romance slim fame pipe puzzle priority actress must impulse tape super bike";
+
+describe("keystore.nostr", () => {
+  beforeEach(() => {
+    resetSecureStoreMock();
+  });
+
+  it("reports no key when secure storage is empty", async () => {
+    await expect(getHasPrivateKeyInSecureStorage()).resolves.toBe(false);
+    await expect(getHasPrivateKeyHexInSecureStorage()).resolves.toBe(false);
+    await expect(getHasPrivateKeyMnemonicInSecureStorage()).resolves.toBe(
+      false,
+    );
+  });
+
+  it("stores and retrieves mnemonic-backed keys", async () => {
+    const account = accountFromSeedWords({ mnemonic });
+
+    await expect(setPrivateKeyInSecureStorage({ mnemonic })).resolves.toBe(
+      account.publicKey.hex,
+    );
+
+    await expect(getPrivateKeyMnemonicFromSecureStorage()).resolves.toBe(
+      mnemonic,
+    );
+    await expect(getPrivateKeyHexFromSecureStorage()).resolves.toBe(
+      account.privateKey.hex,
+    );
+    await expect(getPublicKeyHexFromSecureStorage()).resolves.toEqual({
+      hasMnemonicInSecureStorage: true,
+      publicKeyHex: account.publicKey.hex,
+    });
+  });
+
+  it("stores private hex keys without keeping mnemonic", async () => {
+    const account = accountFromSeedWords({ mnemonic });
+
+    seedSecureStoreMock({
+      [SECURE_STORE_PRIVATE_KEY_HEX_MNEMONIC]: mnemonic,
+    });
+
+    await expect(
+      setPrivateKeyInSecureStorage({ privateKeyHex: account.privateKey.hex }),
+    ).resolves.toBe(account.publicKey.hex);
+
+    await expect(getPrivateKeyHexFromSecureStorage()).resolves.toBe(
+      account.privateKey.hex,
+    );
+    await expect(getHasPrivateKeyMnemonicInSecureStorage()).resolves.toBe(
+      false,
+    );
+  });
+
+  it("rejects invalid stored hex keys", async () => {
+    seedSecureStoreMock({
+      [SECURE_STORE_PRIVATE_KEY_HEX_KEY]: "not-hex",
+    });
+
+    await expect(getPrivateKeyHexFromSecureStorage()).rejects.toThrow(
+      "#1RCMGy-invalid-key-retrieved",
+    );
+  });
+
+  it("derives public keys from mnemonics", () => {
+    const account = accountFromSeedWords({ mnemonic });
+
+    expect(derivePublicKeyHexFromMnemonic(mnemonic)).toBe(
+      account.publicKey.hex,
+    );
+  });
+
+  it("signs event templates with the stored private key", async () => {
+    const account = accountFromSeedWords({ mnemonic });
+    await setPrivateKeyInSecureStorage({ mnemonic });
+
+    await expect(
+      signEventTemplate({
+        content: "hello",
+        created_at: 1,
+        kind: 1,
+        tags: [],
+      }),
+    ).resolves.toMatchObject({
+      content: "hello",
+      kind: 1,
+      pubkey: account.publicKey.hex,
+    });
+  });
+});

--- a/nr-app/src/nostr/nip-46.nostr.test.ts
+++ b/nr-app/src/nostr/nip-46.nostr.test.ts
@@ -1,0 +1,57 @@
+import { accountFromSeedWords } from "nip06";
+import { sendConnectResponse } from "./nip-46.nostr";
+
+jest.mock("nostr-tools", () => ({
+  ...jest.requireActual("nostr-tools"),
+  Relay: (() => {
+    const mockPublish = jest.fn(async () => "ok");
+    const mockRelayConnect = jest.fn(async () => ({ publish: mockPublish }));
+    return {
+      __mockPublish: mockPublish,
+      connect: mockRelayConnect,
+    };
+  })(),
+}));
+
+const relayMock = jest.requireMock("nostr-tools").Relay as {
+  __mockPublish: jest.Mock;
+  connect: jest.Mock;
+};
+
+describe("nip-46.nostr", () => {
+  const clientAccount = accountFromSeedWords({
+    mnemonic:
+      "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+  });
+
+  beforeEach(() => {
+    relayMock.__mockPublish.mockClear();
+    relayMock.connect.mockClear();
+  });
+
+  it("publishes an encrypted connect response", async () => {
+    const clientPubkey = clientAccount.publicKey.hex;
+
+    await sendConnectResponse(
+      `nostrconnect://${clientPubkey}?relay=wss%3A%2F%2Frelay.example&secret=secret123`,
+    );
+
+    expect(relayMock.connect).toHaveBeenCalledWith("wss://relay.example");
+    expect(relayMock.__mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.any(String),
+        kind: 24133,
+        tags: [["p", clientPubkey]],
+      }),
+    );
+  });
+
+  it("does not publish invalid connect URIs", async () => {
+    jest.spyOn(console, "error").mockImplementationOnce(() => undefined);
+
+    await sendConnectResponse("nostrconnect://missing-secret");
+
+    expect(relayMock.connect).not.toHaveBeenCalled();
+    expect(relayMock.__mockPublish).not.toHaveBeenCalled();
+  });
+});

--- a/nr-app/src/nostr/publish.nostr.test.ts
+++ b/nr-app/src/nostr/publish.nostr.test.ts
@@ -1,0 +1,22 @@
+import { createMockRelay, createMockVerifiedEvent } from "@/test/nostrMocks";
+import { publishVerifiedEventToRelay } from "./publish.nostr";
+import { getRelay } from "./relays.nostr";
+
+jest.mock("./relays.nostr", () => ({
+  getRelay: jest.fn(),
+}));
+
+describe("publish.nostr", () => {
+  it("publishes verified events to the requested relay", async () => {
+    const relay = createMockRelay();
+    (getRelay as jest.Mock).mockResolvedValue(relay);
+    const event = createMockVerifiedEvent();
+
+    await expect(
+      publishVerifiedEventToRelay(event, "wss://relay.example"),
+    ).resolves.toBe("ok");
+
+    expect(getRelay).toHaveBeenCalledWith("wss://relay.example");
+    expect(relay.publish).toHaveBeenCalledWith(event);
+  });
+});

--- a/nr-app/src/nostr/relays.nostr.test.ts
+++ b/nr-app/src/nostr/relays.nostr.test.ts
@@ -1,0 +1,35 @@
+describe("relays.nostr", () => {
+  it("connects and reuses relay instances by URL", async () => {
+    const connect = jest.fn(async () => undefined);
+    const relayConstructor = jest.fn(function Relay(
+      this: unknown,
+      url: string,
+    ) {
+      return { connect, url };
+    });
+    relayConstructor.connect = jest.fn(async (url: string) => ({
+      connect,
+      url,
+    }));
+
+    jest.isolateModules(() => {
+      jest.doMock("nostr-tools", () => ({
+        ...jest.requireActual("nostr-tools"),
+        Relay: relayConstructor,
+      }));
+    });
+
+    let relays: typeof import("./relays.nostr");
+    jest.isolateModules(() => {
+      relays = require("./relays.nostr");
+    });
+
+    const first = await relays!.getRelay("wss://relay.example");
+    const second = await relays!.getRelay("wss://relay.example");
+
+    expect(first).toBe(second);
+    expect(relayConstructor).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(relays!.getAllRelays()).toEqual([first]);
+  });
+});

--- a/nr-app/src/nostr/subscriptions.nostr.test.ts
+++ b/nr-app/src/nostr/subscriptions.nostr.test.ts
@@ -1,0 +1,68 @@
+import { createMockRelay, createMockVerifiedEvent } from "@/test/nostrMocks";
+import { getRelay } from "./relays.nostr";
+import {
+  getSubscription,
+  injectStore,
+  stopSubscription,
+  subscribeToFilter,
+} from "./subscriptions.nostr";
+
+jest.mock("./relays.nostr", () => ({
+  getRelay: jest.fn(),
+}));
+
+describe("subscriptions.nostr", () => {
+  it("subscribes to filters and forwards relay callbacks to Redux", async () => {
+    const event = createMockVerifiedEvent();
+    const subscription = { close: jest.fn() };
+    const relay = createMockRelay();
+    relay.subscribe.mockImplementation((_filters, callbacks) => {
+      callbacks.onevent(event);
+      callbacks.oneose();
+      return subscription;
+    });
+    (getRelay as jest.Mock).mockResolvedValue(relay);
+    const store = { dispatch: jest.fn() };
+    injectStore(store as never);
+
+    await expect(
+      subscribeToFilter({
+        filters: [{ kinds: [1] }],
+        relayUrl: "wss://relay.example",
+        subscriptionId: "sub-1",
+      }),
+    ).resolves.toBe("sub-1");
+
+    expect(relay.subscribe).toHaveBeenCalledWith(
+      [{ kinds: [1] }],
+      expect.objectContaining({ subscriptionId: "sub-1" }),
+    );
+    expect(store.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { event, fromRelay: "wss://relay.example" },
+        type: "events/addEvent",
+      }),
+    );
+    expect(getSubscription("sub-1")).toBe(subscription);
+  });
+
+  it("stops subscriptions by id", () => {
+    const subscription = getSubscription("sub-1");
+
+    stopSubscription("sub-1");
+
+    expect(subscription.close).toHaveBeenCalled();
+  });
+
+  it("does not throw when relay connection fails", async () => {
+    (getRelay as jest.Mock).mockRejectedValue(new Error("connection failed"));
+
+    await expect(
+      subscribeToFilter({
+        filters: [{ kinds: [1] }],
+        relayUrl: "ws://10.0.2.2:7777",
+        subscriptionId: "sub-failed",
+      }),
+    ).resolves.toBe("sub-failed");
+  });
+});

--- a/nr-app/src/nostr/subscriptions.nostr.ts
+++ b/nr-app/src/nostr/subscriptions.nostr.ts
@@ -29,7 +29,14 @@ export async function subscribeToFilter({
   relayUrl: string;
   subscriptionId: string;
 }) {
-  const relay = await getRelay(relayUrl);
+  const relay = await getRelay(relayUrl).catch((error) => {
+    if (__DEV__) {
+      console.error("#ZSN5kt Failed to connect to relay", relayUrl, error);
+    }
+    return undefined;
+  });
+
+  if (!relay) return subscriptionId;
 
   const subscription = relay.subscribe(filters, {
     subscriptionId,

--- a/nr-app/src/redux/sagas/map.saga.test.ts
+++ b/nr-app/src/redux/sagas/map.saga.test.ts
@@ -1,0 +1,54 @@
+import {
+  MAP_NOTE_REPOST_KIND,
+  NOSTROOTS_VALIDATION_PUBKEY,
+} from "@trustroots/nr-common";
+import { setVisiblePlusCodes } from "../actions/map.actions";
+import { startSubscription } from "../actions/subscription.actions";
+import { MAP_SUBSCRIPTION_ID, mapActions } from "../slices/map.slice";
+import { createMapFilters, updateDataForMapSagaEffect } from "./map.saga";
+import { put } from "redux-saga/effects";
+
+describe("map.saga", () => {
+  it("builds the Trustroots filter plus enabled layer filters", () => {
+    const filters = createMapFilters(["8F", "9F"], ["hitchwiki", "unverified"]);
+
+    expect(filters).toHaveLength(3);
+    expect(filters[0]).toEqual({
+      kinds: [MAP_NOTE_REPOST_KIND],
+      authors: [NOSTROOTS_VALIDATION_PUBKEY],
+      "#L": ["open-location-code-prefix"],
+      "#l": ["8F", "9F"],
+    });
+    expect(filters[1]).toMatchObject({ kinds: [30399], limit: 500 });
+    expect(filters[2]).toMatchObject({ kinds: [30397], limit: 500 });
+  });
+
+  it("updates map loading state and starts the map subscription", () => {
+    const generator = updateDataForMapSagaEffect(setVisiblePlusCodes(["8F"]));
+    expect(generator.next().value).toMatchObject({ type: "SELECT" });
+    expect(
+      generator.next({
+        visiblePlusCodes: ["8F"],
+        enabledLayerKeys: [],
+      }).value,
+    ).toEqual(put(mapActions.setMapSubscriptionIsUpdating(true)));
+    expect(generator.next().value).toEqual(
+      put(
+        startSubscription({
+          filters: createMapFilters(["8F"], []),
+          id: MAP_SUBSCRIPTION_ID,
+        }),
+      ),
+    );
+    expect(generator.next().done).toBe(true);
+  });
+
+  it("reports map subscription setup failures", () => {
+    const generator = updateDataForMapSagaEffect(setVisiblePlusCodes(["8F"]));
+    generator.next();
+
+    expect(generator.throw(new Error("bad map filter")).value).toEqual(
+      put({ type: "fail", action: "bad map filter" }),
+    );
+  });
+});

--- a/nr-app/src/redux/sagas/map.saga.ts
+++ b/nr-app/src/redux/sagas/map.saga.ts
@@ -30,7 +30,7 @@ const mapSagaSelector = createSelector(
   }),
 );
 
-function createMapFilters(
+export function createMapFilters(
   visiblePlusCodes: string[],
   enabledLayerKeys: MAP_LAYER_KEY[],
 ): Filter[] {
@@ -50,8 +50,8 @@ function createMapFilters(
   return filters;
 }
 
-function* updateDataForMapSagaEffect(
-  action: AnyAction,
+export function* updateDataForMapSagaEffect(
+  _action: AnyAction,
 ): Generator<Effect, void, ReturnType<typeof mapSagaSelector>> {
   try {
     // TODO Debounce map updates

--- a/nr-app/src/redux/sagas/metrics.saga.test.ts
+++ b/nr-app/src/redux/sagas/metrics.saga.test.ts
@@ -1,0 +1,101 @@
+import { createMockVerifiedEvent } from "@/test/nostrMocks";
+import {
+  NOSTROOTS_METRICS_KIND,
+  NOSTROOTS_METRICS_SUPPORTED_TYPES,
+  NOSTROOTS_METRICS_TYPE_MESSAGES,
+  NOSTROOTS_VALIDATION_PUBKEY,
+  NOTIFICATION_SERVER_PUBKEY,
+} from "@trustroots/nr-common";
+import { put, take } from "redux-saga/effects";
+import { rehydrated } from "../actions/startup.actions";
+import { startSubscription } from "../actions/subscription.actions";
+import { addEvent } from "../slices/events.slice";
+import { metricsActions } from "../slices/metrics.slice";
+import {
+  handleMetricsEventEffect,
+  isMetricsEvent,
+  subscribeToMetrics,
+} from "./metrics.saga";
+
+const metricsEvent = (overrides: Record<string, unknown> = {}) =>
+  createMockVerifiedEvent({
+    kind: NOSTROOTS_METRICS_KIND,
+    content: JSON.stringify({ "8FVC0000+": 7 }),
+    tags: [["t", NOSTROOTS_METRICS_TYPE_MESSAGES]],
+    ...overrides,
+  });
+
+describe("metrics.saga", () => {
+  it("recognizes only metrics add-event actions", () => {
+    expect(
+      isMetricsEvent(addEvent({ event: metricsEvent(), fromRelay: "relay" })),
+    ).toBe(true);
+    expect(
+      isMetricsEvent(
+        addEvent({
+          event: createMockVerifiedEvent({ kind: 1 }),
+          fromRelay: "relay",
+        }),
+      ),
+    ).toBe(false);
+    expect(isMetricsEvent({ type: "something/else" })).toBe(false);
+  });
+
+  it("dispatches parsed metrics snapshots", () => {
+    const event = metricsEvent();
+    const generator = handleMetricsEventEffect(
+      addEvent({ event, fromRelay: "relay" }),
+    );
+
+    expect(generator.next().value).toEqual(
+      put(
+        metricsActions.updateMetrics({
+          metricType: NOSTROOTS_METRICS_TYPE_MESSAGES,
+          plusCodeMetrics: { "8FVC0000+": 7 },
+          event,
+        }),
+      ),
+    );
+    expect(generator.next().done).toBe(true);
+  });
+
+  it.each([
+    ["non-metrics events", createMockVerifiedEvent({ kind: 1 })],
+    ["missing metric type", metricsEvent({ tags: [] })],
+    ["unsupported metric type", metricsEvent({ tags: [["t", "unknown"]] })],
+    ["malformed JSON", metricsEvent({ content: "{" })],
+    ["array content", metricsEvent({ content: "[]" })],
+    ["null content", metricsEvent({ content: "null" })],
+  ])("ignores %s", (_case, event) => {
+    const generator = handleMetricsEventEffect(
+      addEvent({ event, fromRelay: "relay" }),
+    );
+
+    expect(generator.next().done).toBe(true);
+  });
+
+  it("subscribes to trusted metrics snapshots after rehydration", () => {
+    const generator = subscribeToMetrics();
+
+    expect(generator.next().value).toEqual(take(rehydrated));
+    expect(generator.next().value).toEqual(
+      put(
+        startSubscription({
+          filters: [
+            {
+              kinds: [NOSTROOTS_METRICS_KIND],
+              authors: [
+                NOSTROOTS_VALIDATION_PUBKEY,
+                NOTIFICATION_SERVER_PUBKEY,
+              ],
+              "#t": [...NOSTROOTS_METRICS_SUPPORTED_TYPES],
+              "#d": ["world"],
+            },
+          ],
+          id: "nostroots-metrics",
+        }),
+      ),
+    );
+    expect(generator.next().done).toBe(true);
+  });
+});

--- a/nr-app/src/redux/sagas/metrics.saga.ts
+++ b/nr-app/src/redux/sagas/metrics.saga.ts
@@ -16,14 +16,14 @@ import { addEvent } from "../slices/events.slice";
 const log = rootLogger.extend("metrics.saga");
 const METRICS_SUBSCRIPTION_ID = "nostroots-metrics";
 
-function isMetricsEvent(action: AnyAction): boolean {
+export function isMetricsEvent(action: AnyAction): boolean {
   return (
     addEvent.match(action) &&
     action.payload.event.kind === NOSTROOTS_METRICS_KIND
   );
 }
 
-function* handleMetricsEventEffect(
+export function* handleMetricsEventEffect(
   action: ReturnType<typeof addEvent>,
 ): Generator<any, void, any> {
   const { event } = action.payload;
@@ -82,7 +82,7 @@ function* metricsEventSaga(): Generator<any, void, any> {
   yield takeEvery(isMetricsEvent, handleMetricsEventEffect);
 }
 
-function* subscribeToMetrics() {
+export function* subscribeToMetrics() {
   yield take(rehydrated);
 
   yield put(

--- a/nr-app/src/redux/sagas/notifications.saga.test.ts
+++ b/nr-app/src/redux/sagas/notifications.saga.test.ts
@@ -1,0 +1,258 @@
+import { createMockVerifiedEvent } from "@/test/nostrMocks";
+import { filterForPlusCode } from "@/utils/notifications.utils";
+import { NOTIFICATION_SERVER_PUBKEY } from "@trustroots/nr-common";
+import { nip04 } from "nostr-tools";
+import { dispatch } from "redux-saga-promise-actions";
+import { call, put } from "redux-saga/effects";
+import {
+  registerDevicePromiseAction,
+  subscribeToPlusCodePromiseAction,
+  unregisterDevicePromiseAction,
+  unsubscribeFromPlusCodePromiseAction,
+} from "../actions/notifications.actions";
+import { startSubscription } from "../actions/subscription.actions";
+import { addEvent } from "../slices/events.slice";
+import {
+  notificationsActions,
+  notificationSelectors,
+} from "../slices/notifications.slice";
+import {
+  handleIncomingSubscriptionEventEffect,
+  isAddEventKind10395Action,
+  registerDeviceSagaEffect,
+  sendNotificationSubscriptionEventAction,
+  startupSagaEffect,
+  subscribeToPlusCodeSagaEffect,
+  unregisterDeviceSagaEffect,
+  unsubscribeFromPlusCodeSagaEffect,
+} from "./notifications.saga";
+import { getPrivateKeyBytesFromSecureStorage } from "@/nostr/keystore.nostr";
+import { registerForPushNotificationsAsync } from "@/services/notifications.service";
+
+const withPromise = <T extends { meta?: unknown }>(action: T) => {
+  const promise = { resolve: jest.fn(), reject: jest.fn() };
+  (action as any).meta.promise = promise;
+  return { action, promise };
+};
+
+describe("notifications.saga", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("registers a device and syncs its token", () => {
+    const { action, promise } = withPromise(
+      registerDevicePromiseAction.request(),
+    );
+    const generator = registerDeviceSagaEffect(action);
+
+    expect(generator.next().value).toEqual(
+      call(registerForPushNotificationsAsync),
+    );
+    expect(generator.next("ExponentPushToken[test]").value).toEqual(
+      put(notificationsActions.addExpoPushToken("ExponentPushToken[test]")),
+    );
+    expect(generator.next().value).toEqual(
+      dispatch(sendNotificationSubscriptionEventAction.request()),
+    );
+    expect(generator.next().value).toEqual(
+      put(registerDevicePromiseAction.success({ success: true })),
+    );
+    expect(generator.next().done).toBe(true);
+    expect(promise.resolve).toHaveBeenCalledWith({ success: true });
+  });
+
+  it("rejects registration when Expo does not return a token", () => {
+    const { action, promise } = withPromise(
+      registerDevicePromiseAction.request(),
+    );
+    const generator = registerDeviceSagaEffect(action);
+    generator.next();
+
+    expect(generator.next(undefined).value).toMatchObject({
+      type: "PUT",
+      payload: {
+        action: {
+          type: "notifications/registerDevice/failure",
+          payload: { message: "#vR8tKm Failed to get push token from Expo" },
+        },
+      },
+    });
+    expect(generator.next().done).toBe(true);
+    expect(promise.reject).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("unregisters an existing token and also succeeds without one", () => {
+    const existing = withPromise(unregisterDevicePromiseAction.request());
+    const generator = unregisterDeviceSagaEffect(existing.action);
+    expect(generator.next().value).toMatchObject({ type: "SELECT" });
+    expect(generator.next("token").value).toEqual(
+      put(notificationsActions.removeExpoPushToken("token")),
+    );
+    expect(generator.next().value).toEqual(
+      dispatch(sendNotificationSubscriptionEventAction.request()),
+    );
+    expect(generator.next().value).toEqual(
+      put(unregisterDevicePromiseAction.success({ success: true })),
+    );
+    expect(generator.next().done).toBe(true);
+    expect(existing.promise.resolve).toHaveBeenCalled();
+
+    const missing = withPromise(unregisterDevicePromiseAction.request());
+    const withoutToken = unregisterDeviceSagaEffect(missing.action);
+    withoutToken.next();
+    expect(withoutToken.next(undefined).value).toEqual(
+      put(unregisterDevicePromiseAction.success({ success: true })),
+    );
+  });
+
+  it("subscribes with an existing push token", () => {
+    const plusCode = "8FVC0000+";
+    const { action, promise } = withPromise(
+      subscribeToPlusCodePromiseAction.request({ plusCode }),
+    );
+    const generator = subscribeToPlusCodeSagaEffect(action);
+
+    expect(generator.next().value).toMatchObject({ type: "SELECT" });
+    expect(generator.next("token").value).toEqual(
+      put(
+        notificationsActions.addFilter({ filter: filterForPlusCode(plusCode) }),
+      ),
+    );
+    expect(generator.next().value).toEqual(
+      dispatch(sendNotificationSubscriptionEventAction.request()),
+    );
+    expect(generator.next().value).toEqual(
+      put(subscribeToPlusCodePromiseAction.success({ success: true })),
+    );
+    expect(generator.next().done).toBe(true);
+    expect(promise.resolve).toHaveBeenCalled();
+  });
+
+  it("registers a token before subscribing when necessary", () => {
+    const plusCode = "8FVC0000+";
+    const { action } = withPromise(
+      subscribeToPlusCodePromiseAction.request({ plusCode }),
+    );
+    const generator = subscribeToPlusCodeSagaEffect(action);
+    generator.next();
+
+    expect(generator.next(undefined).value).toEqual(
+      call(registerForPushNotificationsAsync),
+    );
+    expect(generator.next("new-token").value).toEqual(
+      put(notificationsActions.addExpoPushToken("new-token")),
+    );
+    expect(generator.next().value).toEqual(
+      put(
+        notificationsActions.addFilter({ filter: filterForPlusCode(plusCode) }),
+      ),
+    );
+  });
+
+  it("rejects subscriptions when token registration fails", () => {
+    const { action, promise } = withPromise(
+      subscribeToPlusCodePromiseAction.request({ plusCode: "8FVC0000+" }),
+    );
+    const generator = subscribeToPlusCodeSagaEffect(action);
+    generator.next();
+    generator.next(undefined);
+
+    expect(generator.next(undefined).value).toMatchObject({
+      payload: {
+        action: { type: "notifications/subscribeToPlusCode/failure" },
+      },
+    });
+    expect(generator.next().done).toBe(true);
+    expect(promise.reject).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("removes a plus-code subscription and syncs it", () => {
+    const plusCode = "8FVC0000+";
+    const { action, promise } = withPromise(
+      unsubscribeFromPlusCodePromiseAction.request({ plusCode }),
+    );
+    const generator = unsubscribeFromPlusCodeSagaEffect(action);
+
+    expect(generator.next().value).toEqual(
+      put(
+        notificationsActions.removeFilter({
+          filter: filterForPlusCode(plusCode),
+        }),
+      ),
+    );
+    expect(generator.next().value).toEqual(
+      dispatch(sendNotificationSubscriptionEventAction.request()),
+    );
+    expect(generator.next().value).toEqual(
+      put(unsubscribeFromPlusCodePromiseAction.success({ success: true })),
+    );
+    expect(generator.next().done).toBe(true);
+    expect(promise.resolve).toHaveBeenCalled();
+  });
+
+  it("decrypts valid incoming subscription state", () => {
+    const event = createMockVerifiedEvent({
+      kind: 10395,
+      content: "encrypted",
+    });
+    const generator = handleIncomingSubscriptionEventEffect(
+      addEvent({ event, fromRelay: "relay" }),
+    );
+    const privateKey = new Uint8Array(32).fill(1);
+
+    expect(generator.next().value).toEqual(
+      call(getPrivateKeyBytesFromSecureStorage),
+    );
+    expect(generator.next(privateKey).value).toEqual(
+      call(nip04.decrypt, privateKey, NOTIFICATION_SERVER_PUBKEY, "encrypted"),
+    );
+    expect(
+      generator.next(JSON.stringify({ filters: [], tokens: [] })).value,
+    ).toEqual(put(notificationsActions.setData({ filters: [], tokens: [] })));
+    expect(generator.next().done).toBe(true);
+  });
+
+  it("ignores undecryptable subscription state", () => {
+    const event = createMockVerifiedEvent({ kind: 10395 });
+    const generator = handleIncomingSubscriptionEventEffect(
+      addEvent({ event, fromRelay: "relay" }),
+    );
+    generator.next();
+
+    expect(generator.throw(new Error("decrypt failed")).done).toBe(true);
+  });
+
+  it("recognizes subscription events and starts the private subscription", () => {
+    expect(
+      isAddEventKind10395Action(
+        addEvent({
+          event: createMockVerifiedEvent({ kind: 10395 }),
+          fromRelay: "relay",
+        }),
+      ),
+    ).toBe(true);
+    expect(isAddEventKind10395Action({ type: "other" })).toBe(false);
+
+    const missingKey = startupSagaEffect();
+    expect(missingKey.next().value).toMatchObject({ type: "SELECT" });
+    expect(missingKey.next(undefined).done).toBe(true);
+
+    const withKey = startupSagaEffect();
+    withKey.next();
+    expect(withKey.next("public-key").value).toEqual(
+      put(
+        startSubscription({
+          filters: [{ kinds: [10395], authors: ["public-key"] }],
+          id: "notificationSubscription",
+        }),
+      ),
+    );
+    expect(
+      notificationSelectors.selectExpoPushToken.unwrapped({
+        filters: [],
+        tokens: [{ expoPushToken: "token" }],
+      }),
+    ).toBe("token");
+  });
+});

--- a/nr-app/src/redux/sagas/notifications.saga.ts
+++ b/nr-app/src/redux/sagas/notifications.saga.ts
@@ -83,7 +83,7 @@ export const [
   },
 });
 
-function* registerDeviceSagaEffect(
+export function* registerDeviceSagaEffect(
   action: ReturnType<typeof registerDevicePromiseAction.request>,
 ): Generator<Effect, void, string | undefined> {
   try {
@@ -116,7 +116,7 @@ function* registerDeviceSaga() {
   );
 }
 
-function* unregisterDeviceSagaEffect(
+export function* unregisterDeviceSagaEffect(
   action: ReturnType<typeof unregisterDevicePromiseAction.request>,
 ): Generator<Effect, void, string | undefined> {
   try {
@@ -147,7 +147,7 @@ function* unregisterDeviceSaga() {
   );
 }
 
-function* subscribeToPlusCodeSagaEffect(
+export function* subscribeToPlusCodeSagaEffect(
   action: ReturnType<typeof subscribeToPlusCodePromiseAction.request>,
 ): Generator<Effect, void, string | undefined> {
   try {
@@ -190,7 +190,7 @@ function* subscribeToPlusCodeSaga() {
   );
 }
 
-function* unsubscribeFromPlusCodeSagaEffect(
+export function* unsubscribeFromPlusCodeSagaEffect(
   action: ReturnType<typeof unsubscribeFromPlusCodePromiseAction.request>,
 ): Generator<Effect, void, void> {
   try {
@@ -270,7 +270,7 @@ function isAddEventAction(
   return action.type === addEvent.toString();
 }
 
-function isAddEventKind10395Action(action: AnyAction): boolean {
+export function isAddEventKind10395Action(action: AnyAction): boolean {
   if (!isAddEventAction(action)) {
     return false;
   }
@@ -284,7 +284,7 @@ function* handleIncomingSubscriptionEventSaga() {
   );
 }
 
-function* startupSagaEffect(): Generator<
+export function* startupSagaEffect(): Generator<
   Effect,
   void,
   ReturnType<typeof keystoreSelectors.selectPublicKeyHex>

--- a/nr-app/src/redux/sagas/profiles.saga.test.ts
+++ b/nr-app/src/redux/sagas/profiles.saga.test.ts
@@ -1,0 +1,124 @@
+import { profilesActions } from "../slices/profiles.slice";
+import {
+  fetchKind0FromRelays,
+  fetchProfileWorker,
+  profilesSaga,
+} from "./profiles.saga";
+
+const mockPoolGet = jest.fn();
+const mockPoolClose = jest.fn();
+
+jest.mock("nostr-tools/pool", () => ({
+  SimplePool: jest.fn(() => ({
+    get: mockPoolGet,
+    close: mockPoolClose,
+  })),
+}));
+
+describe("profiles.saga", () => {
+  const pubkey = "1".repeat(64);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, "now").mockReturnValue(1_000_000);
+  });
+
+  it("skips a profile that is still fresh", () => {
+    const generator = fetchProfileWorker(profilesActions.fetchProfile(pubkey));
+
+    expect(generator.next().value).toMatchObject({ type: "SELECT" });
+    expect(generator.next({ fetchedAt: 999 }).value).toMatchObject({
+      type: "PUT",
+      payload: { action: profilesActions.fetchProfileFailed(pubkey) },
+    });
+    expect(generator.next().done).toBe(true);
+  });
+
+  it("stores a profile returned by an active relay", () => {
+    const generator = fetchProfileWorker(profilesActions.fetchProfile(pubkey));
+    generator.next();
+    expect(generator.next(undefined).value).toMatchObject({ type: "SELECT" });
+    expect(generator.next(["wss://relay.example"]).value).toMatchObject({
+      type: "RACE",
+    });
+
+    const result = {
+      content: JSON.stringify({
+        display_name: "Alice",
+        name: "alice",
+        picture: "https://example.com/alice.jpg",
+        about: "Traveler",
+        nip05: "alice@example.com",
+      }),
+    };
+    expect(generator.next({ result }).value).toMatchObject({
+      type: "PUT",
+      payload: {
+        action: profilesActions.setProfile({
+          pubkey,
+          name: "Alice",
+          picture: "https://example.com/alice.jpg",
+          about: "Traveler",
+          nip05: "alice@example.com",
+          fetchedAt: 1000,
+        }),
+      },
+    });
+    expect(generator.next().done).toBe(true);
+  });
+
+  it("falls back to the profile name and handles relay timeouts", () => {
+    const success = fetchProfileWorker(profilesActions.fetchProfile(pubkey));
+    success.next();
+    success.next(undefined);
+    success.next([]);
+    expect(
+      success.next({ result: { content: JSON.stringify({ name: "alice" }) } })
+        .value,
+    ).toMatchObject({
+      payload: { action: { payload: { name: "alice" } } },
+    });
+
+    const timeout = fetchProfileWorker(profilesActions.fetchProfile(pubkey));
+    timeout.next();
+    timeout.next(undefined);
+    timeout.next([]);
+    expect(timeout.next({ timeout: true }).value).toMatchObject({
+      payload: { action: profilesActions.fetchProfileFailed(pubkey) },
+    });
+  });
+
+  it("turns malformed profile content into a failed fetch", () => {
+    jest.spyOn(console, "log").mockImplementation(() => undefined);
+    const generator = fetchProfileWorker(profilesActions.fetchProfile(pubkey));
+    generator.next();
+    generator.next(undefined);
+    generator.next([]);
+
+    expect(generator.next({ result: { content: "{" } }).value).toMatchObject({
+      payload: { action: profilesActions.fetchProfileFailed(pubkey) },
+    });
+  });
+
+  it("fetches kind 0 events and always closes the pool", async () => {
+    const event = { content: "{}" };
+    mockPoolGet.mockResolvedValueOnce(event);
+
+    await expect(
+      fetchKind0FromRelays(pubkey, ["wss://relay.example"]),
+    ).resolves.toBe(event);
+    expect(mockPoolGet).toHaveBeenCalledWith(["wss://relay.example"], {
+      kinds: [0],
+      authors: [pubkey],
+    });
+    expect(mockPoolClose).toHaveBeenCalledWith(["wss://relay.example"]);
+
+    mockPoolGet.mockRejectedValueOnce(new Error("offline"));
+    await expect(fetchKind0FromRelays(pubkey, [])).rejects.toThrow("offline");
+    expect(mockPoolClose).toHaveBeenLastCalledWith([]);
+  });
+
+  it("watches for profile fetch actions", () => {
+    expect(profilesSaga().next().value).toMatchObject({ type: "ALL" });
+  });
+});

--- a/nr-app/src/redux/sagas/profiles.saga.ts
+++ b/nr-app/src/redux/sagas/profiles.saga.ts
@@ -17,7 +17,7 @@ import { relaySelectors } from "../slices/relays.slice";
 const PROFILE_CACHE_SECONDS = 5 * 60;
 const FETCH_TIMEOUT_MS = 5000;
 
-function* fetchProfileWorker(
+export function* fetchProfileWorker(
   action: ReturnType<typeof profilesActions.fetchProfile>,
 ) {
   const pubkey = action.payload;
@@ -67,7 +67,10 @@ function* fetchProfileWorker(
   }
 }
 
-async function fetchKind0FromRelays(pubkey: string, relayUrls: string[]) {
+export async function fetchKind0FromRelays(
+  pubkey: string,
+  relayUrls: string[],
+) {
   const pool = new SimplePool();
   try {
     const event = await pool.get(relayUrls, {

--- a/nr-app/src/redux/sagas/publish.saga.test.ts
+++ b/nr-app/src/redux/sagas/publish.saga.test.ts
@@ -1,0 +1,108 @@
+import { createMockVerifiedEvent } from "@/test/nostrMocks";
+import { publishVerifiedEventToRelay } from "@/nostr/publish.nostr";
+import { signEventTemplate } from "@/nostr/keystore.nostr";
+import {
+  publishEventSagaEffect,
+  publishEventTemplateSagaEffect,
+} from "./publish.saga";
+import {
+  publishEventPromiseAction,
+  publishEventTemplatePromiseAction,
+} from "../actions/publish.actions";
+import { runSaga } from "redux-saga";
+import { DEFAULT_RELAY_URL } from "@trustroots/nr-common";
+
+jest.mock("@/nostr/publish.nostr", () => ({
+  publishVerifiedEventToRelay: jest.fn(async () => "ok"),
+}));
+
+jest.mock("@/nostr/keystore.nostr", () => ({
+  signEventTemplate: jest.fn(),
+}));
+
+describe("publish.saga", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("publishes events to active relays", async () => {
+    const dispatched: unknown[] = [];
+    const event = createMockVerifiedEvent();
+    const action = publishEventPromiseAction.request({ event });
+    action.meta.promise = {
+      reject: jest.fn(),
+      resolve: jest.fn(),
+    };
+
+    await runSaga(
+      {
+        dispatch: (output) => dispatched.push(output),
+        getState: () => ({
+          relays: {
+            relays: {
+              [DEFAULT_RELAY_URL]: {
+                isActive: true,
+                isConnected: false,
+                notices: [],
+                url: DEFAULT_RELAY_URL,
+              },
+            },
+            subscriptions: {},
+          },
+        }),
+      },
+      publishEventSagaEffect,
+      action,
+    ).toPromise();
+
+    expect(publishVerifiedEventToRelay).toHaveBeenCalledWith(
+      event,
+      DEFAULT_RELAY_URL,
+    );
+    expect(dispatched).toContainEqual(
+      publishEventPromiseAction.success({
+        id: event.id,
+        relayResponses: {
+          [DEFAULT_RELAY_URL]: "ok",
+        },
+      }),
+    );
+    expect(action.meta.promise.resolve).toHaveBeenCalledWith({
+      id: event.id,
+      relayResponses: {
+        [DEFAULT_RELAY_URL]: "ok",
+      },
+    });
+  });
+
+  it("signs and dispatches event templates", async () => {
+    const dispatched: unknown[] = [];
+    const event = createMockVerifiedEvent();
+    (signEventTemplate as jest.Mock).mockResolvedValue(event);
+    const eventTemplate = {
+      content: "hello",
+      created_at: 1,
+      kind: 1,
+      tags: [],
+    };
+    const action = publishEventTemplatePromiseAction.request({ eventTemplate });
+    action.meta.promise = {
+      reject: jest.fn(),
+      resolve: jest.fn(),
+    };
+
+    await runSaga(
+      {
+        dispatch: (output) => dispatched.push(output),
+      },
+      publishEventTemplateSagaEffect,
+      action,
+    ).toPromise();
+
+    expect(signEventTemplate).toHaveBeenCalledWith(eventTemplate);
+    expect(dispatched).toContainEqual(
+      publishEventTemplatePromiseAction.success({ event }),
+    );
+    expect(action.meta.promise.resolve).toHaveBeenCalledWith({ event });
+  });
+});

--- a/nr-app/src/redux/sagas/serverMessages.saga.test.ts
+++ b/nr-app/src/redux/sagas/serverMessages.saga.test.ts
@@ -1,0 +1,81 @@
+import { createMockVerifiedEvent } from "@/test/nostrMocks";
+import { SERVER_MESSAGE_KIND } from "@trustroots/nr-common";
+import Toast from "react-native-root-toast";
+import { put, take } from "redux-saga/effects";
+import { rehydrated } from "../actions/startup.actions";
+import { startSubscription } from "../actions/subscription.actions";
+import { addEvent } from "../slices/events.slice";
+import {
+  handleServerMessageEffect,
+  isServerMessageEvent,
+  subscribeToServerMessages,
+} from "./serverMessages.saga";
+
+describe("serverMessages.saga", () => {
+  const messageEvent = (tags: string[][] = []) =>
+    createMockVerifiedEvent({
+      kind: SERVER_MESSAGE_KIND,
+      content: "Relay maintenance tonight",
+      tags,
+    });
+
+  it("recognizes only server-message add-event actions", () => {
+    expect(
+      isServerMessageEvent(
+        addEvent({ event: messageEvent(), fromRelay: "relay" }),
+      ),
+    ).toBe(true);
+    expect(
+      isServerMessageEvent(
+        addEvent({ event: createMockVerifiedEvent(), fromRelay: "relay" }),
+      ),
+    ).toBe(false);
+    expect(isServerMessageEvent({ type: "other" })).toBe(false);
+  });
+
+  it("shows public and correctly targeted server messages", () => {
+    const publicMessage = handleServerMessageEffect(
+      addEvent({ event: messageEvent(), fromRelay: "relay" }),
+    );
+    expect(publicMessage.next().value).toMatchObject({ type: "SELECT" });
+    expect(publicMessage.next("me").done).toBe(true);
+    expect(Toast.show).toHaveBeenCalledWith("Relay maintenance tonight", {
+      duration: Toast.durations.LONG,
+      position: Toast.positions.TOP,
+    });
+
+    const targeted = handleServerMessageEffect(
+      addEvent({ event: messageEvent([["p", "me"]]), fromRelay: "relay" }),
+    );
+    targeted.next();
+    expect(targeted.next("me").done).toBe(true);
+    expect(Toast.show).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores messages targeted at another user", () => {
+    const generator = handleServerMessageEffect(
+      addEvent({
+        event: messageEvent([["p", "someone-else"]]),
+        fromRelay: "relay",
+      }),
+    );
+    generator.next();
+
+    expect(generator.next("me").done).toBe(true);
+    expect(Toast.show).not.toHaveBeenCalled();
+  });
+
+  it("subscribes to server messages after rehydration", () => {
+    const generator = subscribeToServerMessages();
+    expect(generator.next().value).toEqual(take(rehydrated));
+    expect(generator.next().value).toEqual(
+      put(
+        startSubscription({
+          filters: [{ kinds: [SERVER_MESSAGE_KIND] }],
+          id: "serverMessageSubscription",
+        }),
+      ),
+    );
+    expect(generator.next().done).toBe(true);
+  });
+});

--- a/nr-app/src/redux/sagas/serverMessages.saga.ts
+++ b/nr-app/src/redux/sagas/serverMessages.saga.ts
@@ -15,13 +15,15 @@ const log = rootLogger.extend("serverMessages");
 
 const SERVER_MESSAGE_SUBSCRIPTION_ID = "serverMessageSubscription";
 
-function isServerMessageEvent(action: AnyAction): boolean {
+export function isServerMessageEvent(action: AnyAction): boolean {
   return (
     addEvent.match(action) && action.payload.event.kind === SERVER_MESSAGE_KIND
   );
 }
 
-function* handleServerMessageEffect(action: ReturnType<typeof addEvent>) {
+export function* handleServerMessageEffect(
+  action: ReturnType<typeof addEvent>,
+) {
   const { event } = action.payload;
   const publicKeyHex: ReturnType<typeof keystoreSelectors.selectPublicKeyHex> =
     yield select(keystoreSelectors.selectPublicKeyHex);
@@ -43,7 +45,7 @@ function* handleServerMessageSaga() {
   yield takeEvery(isServerMessageEvent, handleServerMessageEffect);
 }
 
-function* subscribeToServerMessages() {
+export function* subscribeToServerMessages() {
   yield take(rehydrated);
 
   yield put(

--- a/nr-app/src/redux/sagas/subscriptions.saga.test.ts
+++ b/nr-app/src/redux/sagas/subscriptions.saga.test.ts
@@ -1,0 +1,162 @@
+import { createMockVerifiedEvent } from "@/test/nostrMocks";
+import {
+  DEFAULT_RELAY_URL,
+  TRUSTROOTS_PROFILE_KIND,
+} from "@trustroots/nr-common";
+import { call, fork, put } from "redux-saga/effects";
+import { subscribeToFilter } from "@/nostr/subscriptions.nostr";
+import {
+  startSubscription,
+  stopSubscription,
+} from "../actions/subscription.actions";
+import { addEvent } from "../slices/events.slice";
+import { setSubscription } from "../slices/relays.slice";
+import {
+  getRelayUrlsOrDefaults,
+  startSubscriptionSagaEffect,
+  stopSubscriptionSagaEffect,
+  subscribeToUserProfilesSagaEffect,
+} from "./subscriptions.saga";
+
+describe("subscriptions.saga", () => {
+  it("uses the default relay when no explicit relays are provided", () => {
+    expect(getRelayUrlsOrDefaults()).toEqual([DEFAULT_RELAY_URL]);
+    expect(getRelayUrlsOrDefaults([])).toEqual([DEFAULT_RELAY_URL]);
+    expect(getRelayUrlsOrDefaults(["wss://relay.example"])).toEqual([
+      "wss://relay.example",
+    ]);
+  });
+
+  it("replaces a named subscription on each requested relay", () => {
+    const filters = [{ kinds: [1] }];
+    const generator = startSubscriptionSagaEffect(
+      startSubscription({
+        id: "notes",
+        filters,
+        relayUrls: ["wss://one.example", "wss://two.example"],
+      }),
+    );
+
+    expect(generator.next().value).toEqual(call(stopSubscription, "notes"));
+    expect(generator.next().value).toEqual(
+      put(
+        setSubscription({
+          subscriptionId: "notes",
+          query: filters,
+          relaysStatus: {
+            "wss://one.example": { hasSeenEOSE: false, isOpen: false },
+            "wss://two.example": { hasSeenEOSE: false, isOpen: false },
+          },
+        }),
+      ),
+    );
+    expect(generator.next().value).toEqual(
+      fork(subscribeToFilter, {
+        filters,
+        relayUrl: "wss://one.example",
+        subscriptionId: "notes",
+      }),
+    );
+    expect(generator.next().value).toEqual(
+      fork(subscribeToFilter, {
+        filters,
+        relayUrl: "wss://two.example",
+        subscriptionId: "notes",
+      }),
+    );
+    expect(generator.next().done).toBe(true);
+  });
+
+  it("generates an id for an unnamed default-relay subscription", () => {
+    const filters = [{ kinds: [1] }];
+    const generator = startSubscriptionSagaEffect(
+      startSubscription({ filters }),
+    );
+    const first = generator.next().value as ReturnType<typeof put>;
+    const subscriptionId = (first.payload.action.payload as any).subscriptionId;
+
+    expect(subscriptionId).toEqual(expect.any(String));
+    expect(first.payload.action.payload.relaysStatus).toEqual({
+      [DEFAULT_RELAY_URL]: { hasSeenEOSE: false, isOpen: false },
+    });
+    expect(generator.next().value).toEqual(
+      fork(subscribeToFilter, {
+        filters,
+        relayUrl: DEFAULT_RELAY_URL,
+        subscriptionId,
+      }),
+    );
+  });
+
+  it("closes a running subscription", () => {
+    const generator = stopSubscriptionSagaEffect(stopSubscription("notes"));
+    const close = jest.fn();
+
+    expect(generator.next().value).toMatchObject({ type: "CALL" });
+    expect(generator.next({ close } as any).value).toEqual(call(close));
+    expect(generator.next().done).toBe(true);
+  });
+
+  it("stops the author subscription when no authors remain", () => {
+    const generator = subscribeToUserProfilesSagaEffect(
+      addEvent({ event: createMockVerifiedEvent(), fromRelay: "relay" }),
+    );
+    expect(generator.next().value).toMatchObject({ type: "SELECT" });
+    expect(
+      generator.next({
+        eventsWithMetadata: [],
+        existingSubscription: undefined,
+      }).value,
+    ).toEqual(put(stopSubscription("authorSubscription")));
+  });
+
+  it("subscribes to every unique event author", () => {
+    const alice = createMockVerifiedEvent({ pubkey: "a".repeat(64) });
+    const bob = createMockVerifiedEvent({ pubkey: "b".repeat(64) });
+    const generator = subscribeToUserProfilesSagaEffect(
+      addEvent({ event: alice, fromRelay: "relay" }),
+    );
+    generator.next();
+
+    expect(
+      generator.next({
+        eventsWithMetadata: [alice, alice, bob].map((event) => ({
+          event,
+          metadata: { seenOnRelays: ["relay"] },
+        })),
+        existingSubscription: undefined,
+      }).value,
+    ).toEqual(
+      put(
+        startSubscription({
+          filters: [
+            {
+              kinds: [TRUSTROOTS_PROFILE_KIND],
+              authors: [alice.pubkey, bob.pubkey],
+            },
+          ],
+          id: "authorSubscription",
+        }),
+      ),
+    );
+  });
+
+  it("keeps an existing author subscription when it is complete", () => {
+    const alice = createMockVerifiedEvent({ pubkey: "a".repeat(64) });
+    const generator = subscribeToUserProfilesSagaEffect(
+      addEvent({ event: alice, fromRelay: "relay" }),
+    );
+    generator.next();
+
+    expect(
+      generator.next({
+        eventsWithMetadata: [
+          { event: alice, metadata: { seenOnRelays: ["relay"] } },
+        ],
+        existingSubscription: {
+          query: [{ authors: [alice.pubkey] }],
+        },
+      } as any).done,
+    ).toBe(true);
+  });
+});

--- a/nr-app/src/redux/sagas/subscriptions.saga.ts
+++ b/nr-app/src/redux/sagas/subscriptions.saga.ts
@@ -29,7 +29,7 @@ import { RootState } from "../store";
 
 const AUTHOR_SUBSCRIPTION_ID = "authorSubscription";
 
-function getRelayUrlsOrDefaults(relayUrls?: string[]) {
+export function getRelayUrlsOrDefaults(relayUrls?: string[]) {
   if (typeof relayUrls === "undefined" || relayUrls.length === 0) {
     // TODO: Get defaults from redux
     const defaultRelayUrls = [DEFAULT_RELAY_URL];
@@ -40,7 +40,7 @@ function getRelayUrlsOrDefaults(relayUrls?: string[]) {
 }
 
 // TODO: Handle network failures here, they will throw
-function* startSubscriptionSagaEffect(
+export function* startSubscriptionSagaEffect(
   action: ReturnType<typeof startSubscription>,
 ) {
   const { filters, id, relayUrls } = action.payload;
@@ -85,7 +85,7 @@ export function* startSubscriptionSaga() {
   yield takeEvery(startSubscription, startSubscriptionSagaEffect);
 }
 
-function* stopSubscriptionSagaEffect(
+export function* stopSubscriptionSagaEffect(
   action: ReturnType<typeof stopSubscription>,
 ): Generator<StrictEffect, void, Subscription> {
   const subscription = yield call(getSubscription, action.payload);
@@ -105,8 +105,8 @@ function selectEventsAndSubscription(state: RootState) {
   return { eventsWithMetadata, existingSubscription };
 }
 
-function* subscribeToUserProfilesSagaEffect(
-  action: ReturnType<typeof addEvent>,
+export function* subscribeToUserProfilesSagaEffect(
+  _action: ReturnType<typeof addEvent>,
 ): Generator<
   StrictEffect,
   void,

--- a/nr-app/src/redux/slices/events.slice.test.ts
+++ b/nr-app/src/redux/slices/events.slice.test.ts
@@ -1,0 +1,81 @@
+import { NOSTR_EXPIRATION_TAG_NAME } from "@trustroots/nr-common";
+
+import {
+  addEvent,
+  eventsActions,
+  eventsSelectors,
+  eventsSlice,
+} from "./events.slice";
+
+function event(
+  overrides: Partial<Parameters<typeof addEvent>[0]["payload"]["event"]> = {},
+) {
+  return {
+    content: "",
+    created_at: 100,
+    id: "0".repeat(64),
+    kind: 1,
+    pubkey: "1".repeat(64),
+    sig: "2".repeat(128),
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe("events.slice", () => {
+  it("adds valid events with relay metadata", () => {
+    const state = eventsSlice.reducer(
+      eventsSlice.getInitialState(),
+      addEvent({ event: event(), fromRelay: "wss://relay.example" }),
+    );
+
+    expect(eventsSelectors.selectAll({ events: state } as never)).toHaveLength(
+      1,
+    );
+    expect(
+      eventsSelectors.selectAll({ events: state } as never)[0].metadata,
+    ).toEqual({
+      seenOnRelays: ["wss://relay.example"],
+    });
+  });
+
+  it("ignores invalid events", () => {
+    const state = eventsSlice.reducer(
+      eventsSlice.getInitialState(),
+      addEvent({
+        event: event({ id: "not-hex" }) as ReturnType<typeof event>,
+        fromRelay: "wss://relay.example",
+      }),
+    );
+
+    expect(eventsSelectors.selectAll({ events: state } as never)).toHaveLength(
+      0,
+    );
+  });
+
+  it("flushes expired events", () => {
+    const unexpired = event({ id: "1".repeat(64) });
+    const expired = event({
+      id: "2".repeat(64),
+      tags: [[NOSTR_EXPIRATION_TAG_NAME, "10"]],
+    });
+    const withEvents = eventsSlice.reducer(
+      eventsSlice.getInitialState(),
+      eventsActions.addEvents({
+        events: [unexpired, expired],
+        fromRelay: "wss://relay.example",
+      }),
+    );
+
+    const flushed = eventsSlice.reducer(
+      withEvents,
+      eventsActions.flushExpiredEvents({ currentTimestampSeconds: 11 }),
+    );
+
+    expect(
+      eventsSelectors
+        .selectAll({ events: flushed } as never)
+        .map(({ event }) => event.id),
+    ).toEqual([unexpired.id]);
+  });
+});

--- a/nr-app/src/redux/slices/keystore.slice.test.ts
+++ b/nr-app/src/redux/slices/keystore.slice.test.ts
@@ -1,0 +1,43 @@
+import { nip19 } from "nostr-tools";
+
+import {
+  keystoreSelectors,
+  keystoreSlice,
+  setPublicKeyHex,
+} from "./keystore.slice";
+
+describe("keystore.slice", () => {
+  it("stores public key information after setting a key", () => {
+    const publicKeyHex = "1".repeat(64);
+    const state = keystoreSlice.reducer(
+      keystoreSlice.getInitialState(),
+      setPublicKeyHex({ hasMnemonic: true, publicKeyHex }),
+    );
+
+    expect(
+      keystoreSelectors.selectHasPrivateKeyHexInSecureStorage.unwrapped(state),
+    ).toBe(true);
+    expect(
+      keystoreSelectors.selectHasPrivateKeyMnemonicInSecureStorage.unwrapped(
+        state,
+      ),
+    ).toBe(true);
+    expect(keystoreSelectors.selectPublicKeyHex.unwrapped(state)).toBe(
+      publicKeyHex,
+    );
+    expect(keystoreSelectors.selectPublicKeyNpub.unwrapped(state)).toBe(
+      nip19.npubEncode(publicKeyHex),
+    );
+  });
+
+  it("defaults to no private key in storage", () => {
+    const state = keystoreSlice.getInitialState();
+
+    expect(
+      keystoreSelectors.selectHasPrivateKeyInSecureStorage.unwrapped(state),
+    ).toBe(false);
+    expect(
+      keystoreSelectors.selectPublicKeyHex.unwrapped(state),
+    ).toBeUndefined();
+  });
+});

--- a/nr-app/src/redux/slices/metrics.slice.test.ts
+++ b/nr-app/src/redux/slices/metrics.slice.test.ts
@@ -1,0 +1,104 @@
+import {
+  NOSTROOTS_METRICS_TYPE_MESSAGES,
+  NOSTROOTS_METRICS_TYPE_PUSH_SUBSCRIPTIONS,
+} from "@trustroots/nr-common";
+import { createMockVerifiedEvent } from "@/test/nostrMocks";
+import {
+  metricsActions,
+  metricsSelectors,
+  metricsSlice,
+} from "./metrics.slice";
+
+describe("metrics.slice", () => {
+  it("merges metric types without replacing existing snapshots", () => {
+    const event = createMockVerifiedEvent({ created_at: 100 });
+    let state = metricsSlice.reducer(
+      undefined,
+      metricsActions.updateMetrics({
+        metricType: NOSTROOTS_METRICS_TYPE_MESSAGES,
+        plusCodeMetrics: { "8F000000+": 12, "8FVC0000+": 4 },
+        event,
+      }),
+    );
+
+    state = metricsSlice.reducer(
+      state,
+      metricsActions.updateMetrics({
+        metricType: NOSTROOTS_METRICS_TYPE_PUSH_SUBSCRIPTIONS,
+        plusCodeMetrics: { "8F000000+": 3 },
+        event: createMockVerifiedEvent({ created_at: 200 }),
+      }),
+    );
+
+    expect(metricsSelectors.selectMetrics.unwrapped(state)).toEqual({
+      "8F000000+": {
+        [NOSTROOTS_METRICS_TYPE_MESSAGES]: 12,
+        [NOSTROOTS_METRICS_TYPE_PUSH_SUBSCRIPTIONS]: 3,
+      },
+      "8FVC0000+": { [NOSTROOTS_METRICS_TYPE_MESSAGES]: 4 },
+    });
+    expect(metricsSelectors.selectLastUpdated.unwrapped(state)).toBe(200);
+  });
+
+  it("selects exact plus-code snapshots and reports missing data", () => {
+    const emptyState = metricsSlice.getInitialState();
+
+    expect(metricsSelectors.selectData.unwrapped(emptyState)).toBe(emptyState);
+    expect(
+      metricsSelectors.selectMetricsByPlusCode.unwrapped(
+        emptyState,
+        "8FVC9G00+",
+      ),
+    ).toBeNull();
+    expect(
+      metricsSelectors.selectPushSubscriptionsMetricByPlusCode.unwrapped(
+        emptyState,
+        "8FVC9G00+",
+      ),
+    ).toBe(0);
+    expect(
+      metricsSelectors.selectMessagesMetricByPlusCode.unwrapped(
+        emptyState,
+        "8FVC9G00+",
+      ),
+    ).toBe(0);
+  });
+
+  it("aggregates subscriptions inherited from broader areas", () => {
+    const state = {
+      metrics: {
+        "8F000000+": { [NOSTROOTS_METRICS_TYPE_PUSH_SUBSCRIPTIONS]: 5 },
+        "8FVC0000+": { [NOSTROOTS_METRICS_TYPE_PUSH_SUBSCRIPTIONS]: 3 },
+        "8FVC9G00+": { [NOSTROOTS_METRICS_TYPE_PUSH_SUBSCRIPTIONS]: 2 },
+        "9F000000+": { [NOSTROOTS_METRICS_TYPE_PUSH_SUBSCRIPTIONS]: 99 },
+      },
+      lastUpdated: 1,
+    };
+
+    expect(
+      metricsSelectors.selectPushSubscriptionsMetricByPlusCode.unwrapped(
+        state,
+        "8FVC9G8F+",
+      ),
+    ).toBe(10);
+  });
+
+  it("aggregates messages from an area and its descendants", () => {
+    const state = {
+      metrics: {
+        "8F000000+": { [NOSTROOTS_METRICS_TYPE_MESSAGES]: 100 },
+        "8FVC0000+": { [NOSTROOTS_METRICS_TYPE_MESSAGES]: 10 },
+        "8FVC9G00+": { [NOSTROOTS_METRICS_TYPE_MESSAGES]: 4 },
+        "9F000000+": { [NOSTROOTS_METRICS_TYPE_MESSAGES]: 99 },
+      },
+      lastUpdated: 1,
+    };
+
+    expect(
+      metricsSelectors.selectMessagesMetricByPlusCode.unwrapped(
+        state,
+        "8FVC0000+",
+      ),
+    ).toBe(14);
+  });
+});

--- a/nr-app/src/redux/slices/notifications.slice.test.ts
+++ b/nr-app/src/redux/slices/notifications.slice.test.ts
@@ -1,0 +1,62 @@
+import {
+  notificationSelectors,
+  notificationsActions,
+  notificationsSlice,
+} from "./notifications.slice";
+
+describe("notifications.slice", () => {
+  it("adds and removes notification filters", () => {
+    const filter = { filter: { kinds: [1], "#g": ["9F4G0000+"] } };
+    const withFilter = notificationsSlice.reducer(
+      notificationsSlice.getInitialState(),
+      notificationsActions.addFilter(filter),
+    );
+
+    expect(notificationSelectors.selectFilters.unwrapped(withFilter)).toEqual([
+      filter,
+    ]);
+
+    const withoutFilter = notificationsSlice.reducer(
+      withFilter,
+      notificationsActions.removeFilter(filter),
+    );
+
+    expect(
+      notificationSelectors.selectFilters.unwrapped(withoutFilter),
+    ).toEqual([]);
+  });
+
+  it("deduplicates Expo push tokens", () => {
+    const withToken = notificationsSlice.reducer(
+      notificationsSlice.getInitialState(),
+      notificationsActions.addExpoPushToken("ExponentPushToken[test]"),
+    );
+    const duplicateState = notificationsSlice.reducer(
+      withToken,
+      notificationsActions.addExpoPushToken("ExponentPushToken[test]"),
+    );
+
+    expect(
+      notificationSelectors.selectTokens.unwrapped(duplicateState),
+    ).toEqual([{ expoPushToken: "ExponentPushToken[test]" }]);
+    expect(
+      notificationSelectors.selectExpoPushToken.unwrapped(duplicateState),
+    ).toBe("ExponentPushToken[test]");
+  });
+
+  it("removes all filters", () => {
+    const withFilter = notificationsSlice.reducer(
+      notificationsSlice.getInitialState(),
+      notificationsActions.addFilter({ filter: { kinds: [1] } }),
+    );
+
+    const emptyState = notificationsSlice.reducer(
+      withFilter,
+      notificationsActions.removeAllFilters(),
+    );
+
+    expect(notificationSelectors.selectFilters.unwrapped(emptyState)).toEqual(
+      [],
+    );
+  });
+});

--- a/nr-app/src/redux/slices/relays.slice.test.ts
+++ b/nr-app/src/redux/slices/relays.slice.test.ts
@@ -1,0 +1,105 @@
+import { DEFAULT_RELAY_URL } from "@trustroots/nr-common";
+
+import {
+  addRelayNotice,
+  relaySelectors,
+  relaysSlice,
+  setRelayConnected,
+  setRelays,
+  setServerClosedMessage,
+  setSubscription,
+  setSubscriptionHasSeenEOSE,
+} from "./relays.slice";
+
+describe("relays.slice", () => {
+  it("selects active relay URLs", () => {
+    const state = relaysSlice.reducer(
+      relaysSlice.getInitialState(),
+      setRelays({
+        "wss://active.example": {
+          url: "wss://active.example",
+          isActive: true,
+          isConnected: false,
+          notices: [],
+        },
+        "wss://inactive.example": {
+          url: "wss://inactive.example",
+          isActive: false,
+          isConnected: false,
+          notices: [],
+        },
+      }),
+    );
+
+    expect(relaySelectors.getActiveRelayUrls.unwrapped(state)).toEqual([
+      "wss://active.example",
+    ]);
+  });
+
+  it("updates relay connection and notices", () => {
+    const connectedState = relaysSlice.reducer(
+      relaysSlice.getInitialState(),
+      setRelayConnected(DEFAULT_RELAY_URL),
+    );
+    const noticeState = relaysSlice.reducer(
+      connectedState,
+      addRelayNotice({
+        relayUrl: DEFAULT_RELAY_URL,
+        notice: { message: "hello", receivedAt: 1 },
+      }),
+    );
+    const disconnectedState = relaysSlice.reducer(
+      noticeState,
+      relaysSlice.actions.setRelayDisconnected(DEFAULT_RELAY_URL),
+    );
+
+    expect(disconnectedState.relays[DEFAULT_RELAY_URL]).toMatchObject({
+      isConnected: false,
+      notices: [{ message: "hello", receivedAt: 1 }],
+    });
+  });
+
+  it("tracks subscription relay status", () => {
+    const subscription = {
+      subscriptionId: "sub-1",
+      query: [{ kinds: [1] }],
+      relaysStatus: {
+        [DEFAULT_RELAY_URL]: {
+          hasSeenEOSE: false,
+          isOpen: true,
+        },
+      },
+    };
+    const subscribedState = relaysSlice.reducer(
+      relaysSlice.getInitialState(),
+      setSubscription(subscription),
+    );
+    const eoseState = relaysSlice.reducer(
+      subscribedState,
+      setSubscriptionHasSeenEOSE({
+        id: "sub-1",
+        relayUrl: DEFAULT_RELAY_URL,
+      }),
+    );
+    const closedState = relaysSlice.reducer(
+      eoseState,
+      setServerClosedMessage({
+        message: "closed",
+        relayUrl: DEFAULT_RELAY_URL,
+        subscriptionId: "sub-1",
+      }),
+    );
+
+    expect(
+      relaySelectors.selectSubscription.unwrapped(closedState, "sub-1"),
+    ).toMatchObject({
+      relaysStatus: {
+        [DEFAULT_RELAY_URL]: {
+          hasSeenEOSE: true,
+          isOpen: false,
+          serverCloseMessage: "closed",
+        },
+      },
+    });
+  });
+});

--- a/nr-app/src/redux/slices/settings.slice.test.ts
+++ b/nr-app/src/redux/slices/settings.slice.test.ts
@@ -4,7 +4,7 @@ import {
   settingsSlice,
 } from "./settings.slice";
 
-describe("settings.slice — useMapLibre feature flag", () => {
+describe("settings.slice", () => {
   it("defaults useMapLibre to false", () => {
     const state = settingsSlice.reducer(undefined, { type: "@@INIT" });
     expect(settingsSelectors.selectUseMapLibre.unwrapped(state)).toBe(false);
@@ -21,5 +21,87 @@ describe("settings.slice — useMapLibre feature flag", () => {
     state = settingsSlice.reducer(state, settingsActions.toggleUseMapLibre());
     state = settingsSlice.reducer(state, settingsActions.toggleUseMapLibre());
     expect(settingsSelectors.selectUseMapLibre.unwrapped(state)).toBe(false);
+  });
+
+  it("stores the selected Trustroots username", () => {
+    const state = settingsSlice.reducer(
+      settingsSlice.getInitialState(),
+      settingsActions.setUsername("alice"),
+    );
+
+    expect(settingsSelectors.selectUsername.unwrapped(state)).toBe("alice");
+  });
+
+  it("tracks pending Trustroots verification usernames", () => {
+    const pendingState = settingsSlice.reducer(
+      settingsSlice.getInitialState(),
+      settingsActions.setPendingTrustrootsUsername("alice"),
+    );
+
+    expect(
+      settingsSelectors.selectPendingTrustrootsUsername.unwrapped(pendingState),
+    ).toBe("alice");
+
+    const clearedState = settingsSlice.reducer(
+      pendingState,
+      settingsActions.clearPendingTrustrootsUsername(),
+    );
+
+    expect(
+      settingsSelectors.selectPendingTrustrootsUsername.unwrapped(clearedState),
+    ).toBeNull();
+  });
+
+  it("tracks pending profile publish usernames", () => {
+    const pendingState = settingsSlice.reducer(
+      settingsSlice.getInitialState(),
+      settingsActions.setPendingTrustrootsProfileUsername("alice"),
+    );
+
+    expect(
+      settingsSelectors.selectPendingTrustrootsProfileUsername.unwrapped(
+        pendingState,
+      ),
+    ).toBe("alice");
+
+    const clearedState = settingsSlice.reducer(
+      pendingState,
+      settingsActions.clearPendingTrustrootsProfileUsername(),
+    );
+
+    expect(
+      settingsSelectors.selectPendingTrustrootsProfileUsername.unwrapped(
+        clearedState,
+      ),
+    ).toBeNull();
+  });
+
+  it("stores color scheme and key import flags", () => {
+    const coloredState = settingsSlice.reducer(
+      settingsSlice.getInitialState(),
+      settingsActions.setColorScheme("dark"),
+    );
+    const importedState = settingsSlice.reducer(
+      coloredState,
+      settingsActions.setKeyWasImported(true),
+    );
+
+    expect(settingsSelectors.selectColorScheme.unwrapped(importedState)).toBe(
+      "dark",
+    );
+    expect(
+      settingsSelectors.selectKeyWasImported.unwrapped(importedState),
+    ).toBe(true);
+  });
+
+  it("toggles test features", () => {
+    const state = settingsSlice.reducer(
+      settingsSlice.getInitialState(),
+      settingsActions.toggleTestFeatures(),
+    );
+
+    expect(
+      settingsSelectors.selectAreTestFeaturesEnabled.unwrapped(state),
+    ).toBe(true);
   });
 });

--- a/nr-app/src/services/notifications.service.test.ts
+++ b/nr-app/src/services/notifications.service.test.ts
@@ -1,0 +1,75 @@
+import * as Notifications from "expo-notifications";
+
+import { setIsDeviceMock } from "@/test/expoDeviceMock";
+import {
+  registerForPushNotificationsAsync,
+  setupNotificationHandling,
+} from "./notifications.service";
+
+describe("notifications.service", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({
+      status: "granted",
+    });
+    (Notifications.requestPermissionsAsync as jest.Mock).mockResolvedValue({
+      status: "granted",
+    });
+    (Notifications.getExpoPushTokenAsync as jest.Mock).mockResolvedValue({
+      data: "ExponentPushToken[test]",
+    });
+  });
+
+  it("registers and returns an Expo push token when permission is granted", async () => {
+    await expect(registerForPushNotificationsAsync()).resolves.toBe(
+      "ExponentPushToken[test]",
+    );
+
+    expect(Notifications.getExpoPushTokenAsync).toHaveBeenCalledWith({
+      projectId: "test-project-id",
+    });
+  });
+
+  it("requests permission before fetching a push token", async () => {
+    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({
+      status: "undetermined",
+    });
+
+    await registerForPushNotificationsAsync();
+
+    expect(Notifications.requestPermissionsAsync).toHaveBeenCalled();
+  });
+
+  it("throws when notification permission is denied", async () => {
+    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({
+      status: "denied",
+    });
+    (Notifications.requestPermissionsAsync as jest.Mock).mockResolvedValue({
+      status: "denied",
+    });
+
+    await expect(registerForPushNotificationsAsync()).rejects.toThrow(
+      "Permission not granted to get push token for push notification!",
+    );
+  });
+
+  it("sets up response handling and returns the subscription", () => {
+    const subscription = { remove: jest.fn() };
+    (
+      Notifications.addNotificationResponseReceivedListener as jest.Mock
+    ).mockReturnValueOnce(subscription);
+
+    expect(setupNotificationHandling()).toBe(subscription);
+    expect(
+      Notifications.addNotificationResponseReceivedListener,
+    ).toHaveBeenCalled();
+  });
+
+  it("throws when running off device", async () => {
+    setIsDeviceMock(false);
+
+    await expect(registerForPushNotificationsAsync()).rejects.toThrow(
+      "Must use physical device for push notifications",
+    );
+  });
+});

--- a/nr-app/src/services/onboardingIdentity.service.test.ts
+++ b/nr-app/src/services/onboardingIdentity.service.test.ts
@@ -1,0 +1,68 @@
+import { nip19 } from "nostr-tools";
+
+import { setPrivateKeyPromiseAction } from "@/redux/sagas/keystore.saga";
+import { setPublicKeyHex } from "@/redux/slices/keystore.slice";
+import { settingsActions } from "@/redux/slices/settings.slice";
+import { ensureOnboardingIdentity } from "./onboardingIdentity.service";
+
+jest.mock("@/nostr/keystore.nostr", () => ({
+  derivePublicKeyHexFromMnemonic: jest.fn(() => "2".repeat(64)),
+  getPublicKeyHexFromSecureStorage: jest.fn(),
+}));
+
+jest.mock("nip06", () => ({
+  generateSeedWords: jest.fn(() => ({ mnemonic: "test seed words" })),
+}));
+
+const keystore = jest.requireMock("@/nostr/keystore.nostr") as {
+  getPublicKeyHexFromSecureStorage: jest.Mock;
+};
+
+describe("onboardingIdentity.service", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns a stored identity and syncs it into Redux", async () => {
+    const publicKeyHex = "1".repeat(64);
+    const dispatch = jest.fn();
+
+    keystore.getPublicKeyHexFromSecureStorage.mockResolvedValue({
+      hasMnemonicInSecureStorage: true,
+      publicKeyHex,
+    });
+
+    await expect(ensureOnboardingIdentity(dispatch)).resolves.toEqual({
+      npub: nip19.npubEncode(publicKeyHex),
+      publicKeyHex,
+      wasGenerated: false,
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      setPublicKeyHex({
+        hasMnemonic: true,
+        publicKeyHex,
+      }),
+    );
+  });
+
+  it("generates and stores a new identity when none exists", async () => {
+    const dispatch = jest.fn(async () => undefined);
+    const publicKeyHex = "2".repeat(64);
+
+    keystore.getPublicKeyHexFromSecureStorage.mockResolvedValue(undefined);
+
+    await expect(ensureOnboardingIdentity(dispatch)).resolves.toEqual({
+      npub: nip19.npubEncode(publicKeyHex),
+      publicKeyHex,
+      wasGenerated: true,
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      setPrivateKeyPromiseAction.request({ mnemonic: "test seed words" }),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      settingsActions.setKeyWasImported(false),
+    );
+  });
+});

--- a/nr-app/src/services/trustrootsProfile.service.test.ts
+++ b/nr-app/src/services/trustrootsProfile.service.test.ts
@@ -1,0 +1,57 @@
+import { publishEventTemplatePromiseAction } from "@/redux/actions/publish.actions";
+import { settingsActions } from "@/redux/slices/settings.slice";
+import { createKind10390EventTemplate } from "@trustroots/nr-common";
+import {
+  finalizeTrustrootsProfilePublish,
+  publishTrustrootsProfile,
+} from "./trustrootsProfile.service";
+
+describe("trustrootsProfile.service", () => {
+  it("publishes a Trustroots profile event template", async () => {
+    const dispatch = jest.fn(async () => undefined);
+    const eventTemplate = createKind10390EventTemplate("alice");
+
+    await publishTrustrootsProfile("alice", dispatch);
+
+    expect(dispatch).toHaveBeenCalledWith(
+      publishEventTemplatePromiseAction.request({ eventTemplate }),
+    );
+  });
+
+  it("tracks pending profile publish while finalizing", async () => {
+    const dispatch = jest.fn(async () => undefined);
+
+    await finalizeTrustrootsProfilePublish("alice", dispatch);
+
+    expect(dispatch).toHaveBeenNthCalledWith(
+      1,
+      settingsActions.setPendingTrustrootsProfileUsername("alice"),
+    );
+    expect(dispatch).toHaveBeenCalledWith(settingsActions.setUsername("alice"));
+    expect(dispatch).toHaveBeenCalledWith(
+      settingsActions.clearPendingTrustrootsUsername(),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      settingsActions.clearPendingTrustrootsProfileUsername(),
+    );
+  });
+
+  it("leaves pending profile username set when publishing fails", async () => {
+    const error = new Error("publish failed");
+    const dispatch = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(error);
+
+    await expect(
+      finalizeTrustrootsProfilePublish("alice", dispatch),
+    ).rejects.toBe(error);
+
+    expect(dispatch).toHaveBeenCalledWith(
+      settingsActions.setPendingTrustrootsProfileUsername("alice"),
+    );
+    expect(dispatch).not.toHaveBeenCalledWith(
+      settingsActions.clearPendingTrustrootsProfileUsername(),
+    );
+  });
+});

--- a/nr-app/src/test/README.md
+++ b/nr-app/src/test/README.md
@@ -1,0 +1,14 @@
+# nr-app Test Utilities
+
+Use the helpers in this folder for Jest and React Native Testing Library tests.
+
+- `renderWithProviders()` renders components with a test Redux store and router spies.
+- `createTestStore()` creates a Redux store with the app slices but without production persistence or automatically started sagas.
+- `router.ts` controls `expo-router` mocks for `push`, `replace`, `dismissTo`, pathnames, search params, and redirects.
+- `secureStoreMock.ts` provides deterministic in-memory `expo-secure-store` behavior.
+- `nostrMocks.ts` contains per-test mock factories for relay, subscription, publish, signing, and NIP-05 boundaries.
+- `fetch.ts` contains deterministic JSON `fetch` helpers.
+
+Prefer mocking at service/network/native boundaries. Screen tests should still assert user-visible behavior, navigation, and dispatched effects through the shared render helper.
+
+Every mock with mutable state must be reset in `beforeEach`. Global reset hooks live in `jest.setup.ts`; per-test module mocks should expose their own reset or be recreated inside each test.

--- a/nr-app/src/test/expoDeviceMock.ts
+++ b/nr-app/src/test/expoDeviceMock.ts
@@ -1,0 +1,17 @@
+let isDevice = true;
+
+export function setIsDeviceMock(value: boolean) {
+  isDevice = value;
+}
+
+export function resetExpoDeviceMock() {
+  isDevice = true;
+}
+
+export function createExpoDeviceMock() {
+  return {
+    get isDevice() {
+      return isDevice;
+    },
+  };
+}

--- a/nr-app/src/test/fetch.ts
+++ b/nr-app/src/test/fetch.ts
@@ -1,0 +1,23 @@
+type JsonResponseOptions = {
+  body?: unknown;
+  ok?: boolean;
+  status?: number;
+};
+
+export function createJsonResponse({
+  body = { success: true },
+  ok = true,
+  status = 200,
+}: JsonResponseOptions = {}) {
+  return {
+    json: jest.fn(async () => body),
+    ok,
+    status,
+  } as unknown as Response;
+}
+
+export function mockFetchJson(options?: JsonResponseOptions) {
+  const fetchMock = jest.fn(async () => createJsonResponse(options));
+  global.fetch = fetchMock;
+  return fetchMock;
+}

--- a/nr-app/src/test/fixtures.ts
+++ b/nr-app/src/test/fixtures.ts
@@ -1,0 +1,69 @@
+import {
+  Event,
+  getPlusCodeAndPlusCodePrefixTags,
+  MAP_NOTE_REPOST_KIND,
+  TRUSTROOTS_PROFILE_KIND,
+} from "@trustroots/nr-common";
+
+import { EventWithMetadata } from "@/redux/slices/events.slice";
+
+export const TEST_PUBKEY =
+  "1111111111111111111111111111111111111111111111111111111111111111";
+export const TEST_RELAY = "wss://relay.example";
+export const TEST_PLUS_CODE = "9F4M0000+";
+
+function hex(seed: string, length: number): string {
+  return seed.repeat(length).slice(0, length);
+}
+
+export function createNostrEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: hex("a", 64),
+    pubkey: TEST_PUBKEY,
+    created_at: 1_800_000_000,
+    kind: MAP_NOTE_REPOST_KIND,
+    tags: getPlusCodeAndPlusCodePrefixTags(TEST_PLUS_CODE),
+    content: "A useful map note",
+    sig: hex("b", 128),
+    ...overrides,
+  };
+}
+
+export function createEventWithMetadata(
+  overrides: Partial<Event> = {},
+): EventWithMetadata {
+  return {
+    event: createNostrEvent(overrides),
+    metadata: {
+      seenOnRelays: [TEST_RELAY],
+    },
+  };
+}
+
+export function createMapNote(
+  overrides: Partial<Event> = {},
+): EventWithMetadata {
+  return createEventWithMetadata({
+    kind: MAP_NOTE_REPOST_KIND,
+    ...overrides,
+  });
+}
+
+export function createProfileEvent({
+  username = "alice",
+  pubkey = TEST_PUBKEY,
+}: {
+  username?: string;
+  pubkey?: string;
+} = {}): EventWithMetadata {
+  return createEventWithMetadata({
+    id: hex("c", 64),
+    pubkey,
+    kind: TRUSTROOTS_PROFILE_KIND,
+    content: JSON.stringify({ name: username }),
+    tags: [
+      ["L", "org.trustroots:username"],
+      ["l", username, "org.trustroots:username"],
+    ],
+  });
+}

--- a/nr-app/src/test/nostrMocks.ts
+++ b/nr-app/src/test/nostrMocks.ts
@@ -1,0 +1,86 @@
+import type { Event, EventTemplate, Filter, VerifiedEvent } from "nostr-tools";
+
+export function createMockVerifiedEvent(
+  overrides: Partial<VerifiedEvent> = {},
+): VerifiedEvent {
+  return {
+    content: "",
+    created_at: 1,
+    id: "0".repeat(64),
+    kind: 1,
+    pubkey: "1".repeat(64),
+    sig: "2".repeat(128),
+    tags: [],
+    ...overrides,
+  };
+}
+
+export function createMockRelay() {
+  return {
+    close: jest.fn(),
+    connect: jest.fn(async () => undefined),
+    publish: jest.fn(async () => "ok"),
+    subscribe: jest.fn(
+      (
+        _filters: Filter[],
+        callbacks?: {
+          oneose?: () => void;
+          onevent?: (event: Event) => void;
+        },
+      ) => {
+        callbacks?.oneose?.();
+        return {
+          close: jest.fn(),
+        };
+      },
+    ),
+  };
+}
+
+export function createMockRelayModule(relay = createMockRelay()) {
+  return {
+    getAllRelays: jest.fn(() => [relay]),
+    getRelay: jest.fn(async () => relay),
+  };
+}
+
+export function createMockPublishModule() {
+  return {
+    publishVerifiedEventToRelay: jest.fn(async () => "ok"),
+  };
+}
+
+export function createMockSubscriptionsModule() {
+  const subscription = { close: jest.fn() };
+  return {
+    getSubscription: jest.fn(() => subscription),
+    injectStore: jest.fn(),
+    stopSubscription: jest.fn(),
+    subscribeToFilter: jest.fn(async () => "test-subscription-id"),
+  };
+}
+
+export function createMockKeystoreModule() {
+  return {
+    derivePublicKeyHexFromMnemonic: jest.fn(() => "1".repeat(64)),
+    getHasPrivateKeyHexInSecureStorage: jest.fn(async () => false),
+    getHasPrivateKeyInSecureStorage: jest.fn(async () => false),
+    getHasPrivateKeyMnemonicInSecureStorage: jest.fn(async () => false),
+    getPrivateKeyHexFromSecureStorage: jest.fn(async () => "3".repeat(64)),
+    getPrivateKeyMnemonicFromSecureStorage: jest.fn(
+      async () =>
+        "romance slim fame pipe puzzle priority actress must impulse tape super bike",
+    ),
+    getPublicKeyHexFromSecureStorage: jest.fn(async () => undefined),
+    setPrivateKeyInSecureStorage: jest.fn(async () => "1".repeat(64)),
+    signEventTemplate: jest.fn(async (template: EventTemplate) =>
+      createMockVerifiedEvent(template),
+    ),
+  };
+}
+
+export function createMockNrCommonNetworkModule() {
+  return {
+    getNip5PubKey: jest.fn(async () => "1".repeat(64)),
+  };
+}

--- a/nr-app/src/test/render.tsx
+++ b/nr-app/src/test/render.tsx
@@ -1,0 +1,6 @@
+export {
+  flushPromises,
+  renderWithProviders,
+  type TestRootState,
+  type TestStore,
+} from "./test-utils";

--- a/nr-app/src/test/router.ts
+++ b/nr-app/src/test/router.ts
@@ -1,0 +1,91 @@
+import type React from "react";
+
+type Href = string | { pathname: string; params?: Record<string, unknown> };
+
+type RouterCalls = {
+  push: jest.Mock;
+  replace: jest.Mock;
+  dismissTo: jest.Mock;
+  back: jest.Mock;
+  canGoBack: jest.Mock<boolean, []>;
+};
+
+type RouterState = {
+  pathname: string;
+  searchParams: Record<string, string | undefined>;
+  router: RouterCalls;
+};
+
+const defaultRouter = {
+  push: jest.fn(),
+  replace: jest.fn(),
+  dismissTo: jest.fn(),
+  back: jest.fn(),
+  canGoBack: jest.fn(() => false),
+};
+
+const routerState: RouterState = {
+  pathname: "/",
+  searchParams: {},
+  router: defaultRouter,
+};
+
+const Redirect = jest.fn(({ href }: { href: Href }) => {
+  routerState.router.replace(href);
+  return null;
+});
+const useLocalSearchParams = jest.fn(() => routerState.searchParams);
+const usePathname = jest.fn(() => routerState.pathname);
+const useRouter = jest.fn(() => routerState.router);
+
+export function resetRouterMock() {
+  routerState.pathname = "/";
+  routerState.searchParams = {};
+  Object.values(routerState.router).forEach((mock) => mock.mockClear());
+  routerState.router.canGoBack.mockReturnValue(false);
+  Redirect.mockClear();
+  useLocalSearchParams.mockClear();
+  useLocalSearchParams.mockImplementation(() => routerState.searchParams);
+  usePathname.mockClear();
+  usePathname.mockImplementation(() => routerState.pathname);
+  useRouter.mockClear();
+  useRouter.mockImplementation(() => routerState.router);
+}
+
+export function setRouterPathname(pathname: string) {
+  routerState.pathname = pathname;
+}
+
+export function setRouterSearchParams(
+  searchParams: Record<string, string | undefined>,
+) {
+  routerState.searchParams = searchParams;
+}
+
+export function getRouterMock() {
+  return routerState.router;
+}
+
+export function createExpoRouterMock() {
+  const Slot = ({ children }: { children?: React.ReactNode }) =>
+    children ?? null;
+  const Stack = ({ children }: { children?: React.ReactNode }) =>
+    children ?? null;
+  Stack.Screen = () => null;
+
+  return {
+    Redirect,
+    Slot,
+    Stack,
+    Tabs: ({ children }: { children?: React.ReactNode }) => children ?? null,
+    Link: ({ children }: { children?: React.ReactNode }) => children ?? null,
+    router: routerState.router,
+    useFocusEffect: (callback: () => void | (() => void)) => {
+      const React = require("react");
+      React.useEffect(callback, [callback]);
+    },
+    useLocalSearchParams,
+    usePathname,
+    useRouter,
+  };
+}

--- a/nr-app/src/test/routes/index.test.tsx
+++ b/nr-app/src/test/routes/index.test.tsx
@@ -1,0 +1,55 @@
+import { waitFor } from "@testing-library/react-native";
+
+import { ROUTES } from "@/constants/routes";
+import { keystoreSlice } from "@/redux/slices/keystore.slice";
+import { settingsSlice } from "@/redux/slices/settings.slice";
+import { renderWithProviders } from "@/test/render";
+import IndexRoute from "../../../app/index";
+
+function loadedSettings(overrides = {}) {
+  return {
+    ...settingsSlice.getInitialState(),
+    hasBeenOpenedBefore: true,
+    isDataLoaded: true,
+    ...overrides,
+  };
+}
+
+describe("IndexRoute", () => {
+  it("redirects first-time users to welcome", async () => {
+    const { router } = renderWithProviders(<IndexRoute />, {
+      preloadedState: {
+        settings: loadedSettings({ hasBeenOpenedBefore: false }),
+      },
+    });
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith(ROUTES.WELCOME);
+    });
+  });
+
+  it("redirects users without identity to onboarding", async () => {
+    const { router } = renderWithProviders(<IndexRoute />, {
+      preloadedState: {
+        keystore: keystoreSlice.getInitialState(),
+        settings: loadedSettings(),
+      },
+    });
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith(ROUTES.ONBOARDING);
+    });
+  });
+
+  it("honors the force welcome feature flag", async () => {
+    const { router } = renderWithProviders(<IndexRoute />, {
+      preloadedState: {
+        settings: loadedSettings({ forceWelcome: true }),
+      },
+    });
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith(ROUTES.WELCOME);
+    });
+  });
+});

--- a/nr-app/src/test/routes/main/settings.test.tsx
+++ b/nr-app/src/test/routes/main/settings.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
+
+import { settingsSlice } from "@/redux/slices/settings.slice";
+import { renderWithProviders } from "@/test/render";
+import SettingsScreen from "../../../../app/(main)/(views)/settings";
+
+const mockImportKey = jest.fn(async () => ({
+  success: true,
+  type: "mnemonic",
+}));
+
+jest.mock("@/hooks/useKeyImport", () => ({
+  useKeyImport: () => ({
+    clearError: jest.fn(),
+    error: null,
+    importKey: mockImportKey,
+    isImporting: false,
+  }),
+}));
+
+describe("SettingsScreen", () => {
+  it("renders notification, import key, appearance, and help sections", () => {
+    renderWithProviders(<SettingsScreen />);
+
+    expect(screen.getByText("Notifications")).toBeTruthy();
+    expect(screen.getAllByText("Import Key").length).toBeGreaterThan(0);
+    expect(screen.getByText("Appearance")).toBeTruthy();
+    expect(screen.getByText("Help")).toBeTruthy();
+  });
+
+  it("updates color scheme preference", () => {
+    const { store } = renderWithProviders(<SettingsScreen />);
+
+    fireEvent.press(screen.getByText("Dark"));
+
+    expect(store.getState().settings.colorScheme).toBe("dark");
+  });
+
+  it("shows test feature controls when enabled", async () => {
+    renderWithProviders(<SettingsScreen />, {
+      preloadedState: {
+        settings: {
+          ...settingsSlice.getInitialState(),
+          areTestFeaturesEnabled: true,
+        },
+      },
+    });
+
+    expect(screen.getByText("Notification Debug")).toBeTruthy();
+    expect(screen.getByText("Set visible plus codes")).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        screen.getByText("No websites have used NIP-07 yet."),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/nr-app/src/test/routes/onboarding/backup-confirm.test.tsx
+++ b/nr-app/src/test/routes/onboarding/backup-confirm.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
+
+import { setPrivateKeyInSecureStorage } from "@/nostr/keystore.nostr";
+import { settingsSlice } from "@/redux/slices/settings.slice";
+import { renderWithProviders } from "@/test/render";
+import { resetSecureStoreMock } from "@/test/secureStoreMock";
+import OnboardingBackupConfirmScreen from "../../../../app/onboarding/backup-confirm";
+
+const mnemonic =
+  "romance slim fame pipe puzzle priority actress must impulse tape super bike";
+
+describe("OnboardingBackupConfirmScreen", () => {
+  beforeEach(() => {
+    resetSecureStoreMock();
+  });
+
+  it("shows setup error when no key is present", async () => {
+    renderWithProviders(<OnboardingBackupConfirmScreen />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "We could not find your key on this device. Please restart onboarding.",
+        ),
+      ).toBeTruthy();
+    });
+  });
+
+  it("confirms a generated mnemonic backup", async () => {
+    await setPrivateKeyInSecureStorage({ mnemonic });
+
+    const { router } = renderWithProviders(<OnboardingBackupConfirmScreen />, {
+      preloadedState: {
+        settings: {
+          ...settingsSlice.getInitialState(),
+          keyWasImported: false,
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Save this secret before continuing"),
+      ).toBeTruthy();
+    });
+
+    fireEvent.changeText(
+      screen.getByPlaceholderText(
+        "Paste your nsec1... key or type your 12/24-word mnemonic",
+      ),
+      mnemonic,
+    );
+    fireEvent.press(screen.getByText("Confirm backup"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("You’re all set — backup confirmed."),
+      ).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByText("Finish"));
+
+    expect(router.replace).toHaveBeenCalledWith("/(main)/(map)");
+  });
+});

--- a/nr-app/src/test/routes/onboarding/identity.test.tsx
+++ b/nr-app/src/test/routes/onboarding/identity.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, screen } from "@testing-library/react-native";
+
+import { ROUTES } from "@/constants/routes";
+import { renderWithProviders } from "@/test/render";
+import OnboardingIdentityScreen from "../../../../app/onboarding/identity";
+
+describe("OnboardingIdentityScreen", () => {
+  it("continues to Trustroots verification", () => {
+    const { router } = renderWithProviders(<OnboardingIdentityScreen />);
+
+    fireEvent.press(screen.getByText("Continue"));
+
+    expect(router.push).toHaveBeenCalledWith("/onboarding/trustroots");
+  });
+
+  it("allows browsing as a guest", () => {
+    const { router } = renderWithProviders(<OnboardingIdentityScreen />);
+
+    fireEvent.press(screen.getByText("Browse first"));
+
+    expect(router.replace).toHaveBeenCalledWith(ROUTES.HOME);
+  });
+
+  it("shows back when router can go back", () => {
+    const { router } = renderWithProviders(<OnboardingIdentityScreen />, {
+      canGoBack: true,
+    });
+    fireEvent.press(screen.getByText("Back"));
+
+    expect(router.back).toHaveBeenCalled();
+  });
+});

--- a/nr-app/src/test/routes/onboarding/key.test.tsx
+++ b/nr-app/src/test/routes/onboarding/key.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
+
+import { renderWithProviders } from "@/test/render";
+import OnboardingKeyScreen from "../../../../app/onboarding/key";
+
+const mockImportKey = jest.fn(async () => ({
+  success: true,
+  type: "mnemonic",
+}));
+const mockClearError = jest.fn();
+
+jest.mock("@/hooks/useKeyImport", () => ({
+  useKeyImport: () => ({
+    clearError: mockClearError,
+    error: null,
+    importKey: mockImportKey,
+    isImporting: false,
+  }),
+}));
+
+describe("OnboardingKeyScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("imports an existing key before continuing to legacy link flow", async () => {
+    const { router } = renderWithProviders(<OnboardingKeyScreen />);
+
+    fireEvent.changeText(
+      screen.getByPlaceholderText("Paste your nsec or mnemonic"),
+      "test mnemonic",
+    );
+    fireEvent.press(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockImportKey).toHaveBeenCalledWith("test mnemonic");
+      expect(screen.getByText("Saved")).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByText("Continue"));
+
+    await waitFor(() => {
+      expect(router.push).toHaveBeenCalledWith("/onboarding/link");
+    });
+  });
+
+  it("goes back to identity when there is no router history", () => {
+    const { router } = renderWithProviders(<OnboardingKeyScreen />);
+
+    fireEvent.press(screen.getByText("Back"));
+
+    expect(router.dismissTo).toHaveBeenCalledWith("/onboarding/identity");
+  });
+});

--- a/nr-app/src/test/routes/onboarding/link.test.tsx
+++ b/nr-app/src/test/routes/onboarding/link.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, screen } from "@testing-library/react-native";
+
+import { ROUTES } from "@/constants/routes";
+import { keystoreSlice } from "@/redux/slices/keystore.slice";
+import { settingsSlice } from "@/redux/slices/settings.slice";
+import { renderWithProviders } from "@/test/render";
+import OnboardingLinkScreen from "../../../../app/onboarding/link";
+
+jest.mock("nostr-tools", () => ({
+  ...jest.requireActual("nostr-tools"),
+  nip05: {
+    ...jest.requireActual("nostr-tools").nip05,
+    queryProfile: jest.fn(),
+  },
+}));
+
+const mockQueryProfile = jest.requireMock("nostr-tools").nip05
+  .queryProfile as jest.Mock;
+
+jest.mock("@/services/trustrootsProfile.service", () => ({
+  publishTrustrootsProfile: jest.fn(async () => undefined),
+}));
+
+describe("OnboardingLinkScreen", () => {
+  const publicKeyHex = "1".repeat(64);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows an error when NIP-05 verification fails", async () => {
+    mockQueryProfile.mockResolvedValue({
+      pubkey: "2".repeat(64),
+      relays: [],
+    });
+    const { router } = renderWithProviders(<OnboardingLinkScreen />, {
+      preloadedState: {
+        keystore: {
+          ...keystoreSlice.getInitialState(),
+          hasPrivateKeyHexInSecureStorage: true,
+          publicKeyHex,
+          publicKeyNpub:
+            "npub1zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygse4sl3h",
+        },
+        settings: {
+          ...settingsSlice.getInitialState(),
+          keyWasImported: true,
+        },
+      },
+    });
+
+    fireEvent.changeText(
+      screen.getByPlaceholderText("Enter your Trustroots username"),
+      "alice",
+    );
+    fireEvent.press(screen.getByText("Verify"));
+
+    expect(await screen.findByText("Try Again")).toBeTruthy();
+    expect(
+      screen.getByText(/npub returned by Trustroots does not match/),
+    ).toBeTruthy();
+    expect(router.replace).not.toHaveBeenCalledWith(ROUTES.HOME);
+  });
+
+  it("disables verification when no key is available", () => {
+    renderWithProviders(<OnboardingLinkScreen />);
+
+    expect(
+      screen.getByText("Nostr key not found on this device."),
+    ).toBeTruthy();
+    expect(screen.getByText("Verify")).toBeDisabled();
+  });
+});

--- a/nr-app/src/test/routes/onboarding/trustroots.test.tsx
+++ b/nr-app/src/test/routes/onboarding/trustroots.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
+
+import { settingsSlice } from "@/redux/slices/settings.slice";
+import { renderWithProviders } from "@/test/render";
+import OnboardingTrustrootsScreen from "../../../../app/onboarding/trustroots";
+
+jest.mock("@/services/nrBridge.service", () => {
+  const actual = jest.requireActual("@/services/nrBridge.service");
+  return {
+    ...actual,
+    authenticateWithCode: jest.fn(async () => undefined),
+    requestVerificationToken: jest.fn(async () => undefined),
+  };
+});
+
+jest.mock("@/services/onboardingIdentity.service", () => ({
+  ensureOnboardingIdentity: jest.fn(async () => ({ npub: "npub1test" })),
+}));
+
+jest.mock("@/services/trustrootsProfile.service", () => ({
+  finalizeTrustrootsProfilePublish: jest.fn(async () => undefined),
+}));
+
+const bridge = jest.requireMock("@/services/nrBridge.service") as {
+  authenticateWithCode: jest.Mock;
+  requestVerificationToken: jest.Mock;
+};
+
+describe("OnboardingTrustrootsScreen", () => {
+  it("validates username before requesting a code", () => {
+    renderWithProviders(<OnboardingTrustrootsScreen />);
+
+    fireEvent.press(screen.getByText("Verify Trustroots email"));
+
+    expect(screen.getByText("Enter your Trustroots username.")).toBeTruthy();
+    expect(bridge.requestVerificationToken).not.toHaveBeenCalled();
+  });
+
+  it("requests a code and enters code-entry state", async () => {
+    renderWithProviders(<OnboardingTrustrootsScreen />);
+
+    fireEvent.changeText(screen.getByPlaceholderText("your-username"), "Alice");
+    fireEvent.press(screen.getByText("Verify Trustroots email"));
+
+    await waitFor(() => {
+      expect(bridge.requestVerificationToken).toHaveBeenCalledWith("alice");
+      expect(screen.getByText("Six-digit code")).toBeTruthy();
+    });
+  });
+
+  it("authenticates a six-digit code and routes to backup", async () => {
+    const { router } = renderWithProviders(<OnboardingTrustrootsScreen />, {
+      preloadedState: {
+        settings: {
+          ...settingsSlice.getInitialState(),
+          pendingTrustrootsUsername: "alice",
+        },
+      },
+    });
+
+    fireEvent.changeText(screen.getByPlaceholderText("123456"), "12a3456");
+    fireEvent.press(screen.getByText("Verify code"));
+
+    await waitFor(() => {
+      expect(bridge.authenticateWithCode).toHaveBeenCalledWith({
+        code: "123456",
+        npub: "npub1test",
+        username: "alice",
+      });
+      expect(router.replace).toHaveBeenCalledWith(
+        "/onboarding/backup-confirm?from=bridge",
+      );
+    });
+  });
+});

--- a/nr-app/src/test/routes/verify.test.tsx
+++ b/nr-app/src/test/routes/verify.test.tsx
@@ -1,0 +1,68 @@
+import { waitFor } from "@testing-library/react-native";
+
+import { settingsSlice } from "@/redux/slices/settings.slice";
+import { renderWithProviders } from "@/test/render";
+import VerifyRoute from "../../../app/verify";
+
+jest.mock("@/services/nrBridge.service", () => ({
+  authenticateWithToken: jest.fn(async () => undefined),
+}));
+
+jest.mock("@/services/onboardingIdentity.service", () => ({
+  ensureOnboardingIdentity: jest.fn(async () => ({ npub: "npub1test" })),
+}));
+
+jest.mock("@/services/trustrootsProfile.service", () => ({
+  finalizeTrustrootsProfilePublish: jest.fn(async () => undefined),
+}));
+
+const bridge = jest.requireMock("@/services/nrBridge.service") as {
+  authenticateWithToken: jest.Mock;
+};
+
+describe("VerifyRoute", () => {
+  it("routes to Trustroots when the token is missing", async () => {
+    const { router } = renderWithProviders(<VerifyRoute />);
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith(
+        "/onboarding/trustroots?error=missing-token",
+      );
+    });
+  });
+
+  it("routes to Trustroots when verification did not start in app", async () => {
+    const { router } = renderWithProviders(<VerifyRoute />, {
+      searchParams: { token: "token-1" },
+    });
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith(
+        "/onboarding/trustroots?error=start-in-app",
+      );
+    });
+  });
+
+  it("authenticates token for a pending username", async () => {
+    const { router } = renderWithProviders(<VerifyRoute />, {
+      preloadedState: {
+        settings: {
+          ...settingsSlice.getInitialState(),
+          pendingTrustrootsUsername: "alice",
+        },
+      },
+      searchParams: { token: "token-1" },
+    });
+
+    await waitFor(() => {
+      expect(bridge.authenticateWithToken).toHaveBeenCalledWith({
+        npub: "npub1test",
+        token: "token-1",
+        username: "alice",
+      });
+      expect(router.replace).toHaveBeenCalledWith(
+        "/onboarding/backup-confirm?from=bridge",
+      );
+    });
+  });
+});

--- a/nr-app/src/test/routes/welcome.test.tsx
+++ b/nr-app/src/test/routes/welcome.test.tsx
@@ -1,0 +1,17 @@
+import { fireEvent, screen } from "@testing-library/react-native";
+
+import { renderWithProviders } from "@/test/render";
+import WelcomeScreen from "../../../app/welcome";
+
+describe("WelcomeScreen", () => {
+  it("renders first-impression copy and starts onboarding", () => {
+    const { router } = renderWithProviders(<WelcomeScreen />);
+
+    expect(screen.getByText("Welcome to Nostroots")).toBeTruthy();
+    expect(screen.getByText(/Connect with travelers and locals/)).toBeTruthy();
+
+    fireEvent.press(screen.getByText("Get Started"));
+
+    expect(router.replace).toHaveBeenCalledWith("/onboarding");
+  });
+});

--- a/nr-app/src/test/secureStoreMock.ts
+++ b/nr-app/src/test/secureStoreMock.ts
@@ -1,0 +1,24 @@
+const secureStore = new Map<string, string>();
+
+export function resetSecureStoreMock() {
+  secureStore.clear();
+}
+
+export function seedSecureStoreMock(values: Record<string, string>) {
+  Object.entries(values).forEach(([key, value]) => {
+    secureStore.set(key, value);
+  });
+}
+
+export function createSecureStoreMock() {
+  return {
+    AFTER_FIRST_UNLOCK: "AFTER_FIRST_UNLOCK",
+    deleteItemAsync: jest.fn(async (key: string) => {
+      secureStore.delete(key);
+    }),
+    getItemAsync: jest.fn(async (key: string) => secureStore.get(key) ?? null),
+    setItemAsync: jest.fn(async (key: string, value: string) => {
+      secureStore.set(key, value);
+    }),
+  };
+}

--- a/nr-app/src/test/test-utils.tsx
+++ b/nr-app/src/test/test-utils.tsx
@@ -1,0 +1,124 @@
+import { combineSlices, configureStore } from "@reduxjs/toolkit";
+import { render, RenderOptions } from "@testing-library/react-native";
+import React, { PropsWithChildren, ReactElement } from "react";
+import { Provider } from "react-redux";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+
+import { eventsSlice } from "@/redux/slices/events.slice";
+import { keystoreSlice } from "@/redux/slices/keystore.slice";
+import { mapSlice } from "@/redux/slices/map.slice";
+import { metricsSlice } from "@/redux/slices/metrics.slice";
+import { notificationsSlice } from "@/redux/slices/notifications.slice";
+import { profilesSlice } from "@/redux/slices/profiles.slice";
+import { relaysSlice } from "@/redux/slices/relays.slice";
+import { settingsSlice } from "@/redux/slices/settings.slice";
+import {
+  getRouterMock,
+  resetRouterMock,
+  setRouterPathname,
+  setRouterSearchParams,
+} from "./router";
+
+const testRootReducer = combineSlices(
+  eventsSlice,
+  keystoreSlice,
+  mapSlice,
+  metricsSlice,
+  notificationsSlice,
+  profilesSlice,
+  relaysSlice,
+  settingsSlice,
+);
+
+export type TestRootState = ReturnType<typeof testRootReducer>;
+export type TestStore = ReturnType<typeof createTestStore>;
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends Record<string, unknown>
+    ? DeepPartial<T[K]>
+    : T[K];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mergeState<T>(base: T, overrides: DeepPartial<T>): T {
+  if (!isRecord(base) || !isRecord(overrides)) {
+    return (overrides ?? base) as T;
+  }
+
+  const output: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(overrides)) {
+    const baseValue = output[key];
+    output[key] =
+      isRecord(baseValue) && isRecord(value)
+        ? mergeState(baseValue, value)
+        : value;
+  }
+  return output as T;
+}
+
+export function createTestStore(
+  preloadedState: DeepPartial<TestRootState> = {},
+) {
+  const initialState = testRootReducer(undefined, { type: "@@test/init" });
+
+  return configureStore({
+    reducer: testRootReducer,
+    preloadedState: mergeState(initialState, preloadedState),
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+        immutableCheck: false,
+      }),
+  });
+}
+
+export function renderWithProviders(
+  ui: ReactElement,
+  {
+    canGoBack = false,
+    pathname = "/",
+    preloadedState,
+    searchParams = {},
+    store = createTestStore(preloadedState),
+    ...renderOptions
+  }: RenderOptions & {
+    canGoBack?: boolean;
+    pathname?: string;
+    preloadedState?: DeepPartial<TestRootState>;
+    searchParams?: Record<string, string | undefined>;
+    store?: TestStore;
+  } = {},
+) {
+  resetRouterMock();
+  setRouterPathname(pathname);
+  setRouterSearchParams(searchParams);
+  getRouterMock().canGoBack.mockReturnValue(canGoBack);
+
+  function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <Provider store={store}>
+        <SafeAreaProvider
+          initialMetrics={{
+            frame: { x: 0, y: 0, width: 390, height: 844 },
+            insets: { top: 47, right: 0, bottom: 34, left: 0 },
+          }}
+        >
+          {children}
+        </SafeAreaProvider>
+      </Provider>
+    );
+  }
+
+  return {
+    router: getRouterMock(),
+    store,
+    ...render(ui, { wrapper: Wrapper, ...renderOptions }),
+  };
+}
+
+export async function flushPromises() {
+  await new Promise((resolve) => setImmediate(resolve));
+}

--- a/nr-app/src/test/testStore.ts
+++ b/nr-app/src/test/testStore.ts
@@ -1,0 +1,71 @@
+import { combineSlices, configureStore } from "@reduxjs/toolkit";
+import { promiseMiddleware } from "redux-saga-promise-actions";
+
+import { eventsSlice } from "@/redux/slices/events.slice";
+import { keystoreSlice } from "@/redux/slices/keystore.slice";
+import { mapSlice } from "@/redux/slices/map.slice";
+import { metricsSlice } from "@/redux/slices/metrics.slice";
+import { notificationsSlice } from "@/redux/slices/notifications.slice";
+import { profilesSlice } from "@/redux/slices/profiles.slice";
+import { relaysSlice } from "@/redux/slices/relays.slice";
+import { settingsSlice } from "@/redux/slices/settings.slice";
+
+export const testRootReducer = combineSlices(
+  eventsSlice,
+  keystoreSlice,
+  mapSlice,
+  metricsSlice,
+  notificationsSlice,
+  profilesSlice,
+  relaysSlice,
+  settingsSlice,
+);
+
+export type TestRootState = ReturnType<typeof testRootReducer>;
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends Record<string, unknown>
+    ? DeepPartial<T[K]>
+    : T[K];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mergeState<T>(base: T, overrides: DeepPartial<T>): T {
+  if (!isRecord(base) || !isRecord(overrides)) {
+    return (overrides ?? base) as T;
+  }
+
+  const output: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(overrides)) {
+    const baseValue = output[key];
+    output[key] =
+      isRecord(baseValue) && isRecord(value)
+        ? mergeState(baseValue, value)
+        : value;
+  }
+  return output as T;
+}
+
+export function createTestStore(
+  preloadedState: DeepPartial<TestRootState> = {},
+) {
+  const initialState = testRootReducer(undefined, { type: "@@test/init" });
+
+  return configureStore({
+    reducer: testRootReducer,
+    preloadedState: mergeState(initialState, preloadedState),
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        thunk: true,
+        serializableCheck: false,
+        immutableCheck: false,
+      }).prepend(promiseMiddleware),
+    devTools: false,
+  });
+}
+
+export type TestStore = ReturnType<typeof createTestStore>;
+export type TestAppDispatch = TestStore["dispatch"];

--- a/nr-app/src/utils/error.utils.test.ts
+++ b/nr-app/src/utils/error.utils.test.ts
@@ -1,0 +1,24 @@
+import { getSerializableError } from "./error.utils";
+
+describe("error.utils", () => {
+  it("serializes Error instances with optional code and data", () => {
+    const error = Object.assign(new Error("Boom"), {
+      code: "ERR_TEST",
+      data: { detail: true },
+    });
+
+    expect(getSerializableError(error)).toEqual({
+      code: "ERR_TEST",
+      data: { detail: true },
+      message: "Boom",
+      name: "ERR_TEST",
+    });
+  });
+
+  it("returns a fallback for non-error values", () => {
+    expect(getSerializableError("nope")).toEqual({
+      message: "getSerializableError called on non error",
+      name: "7VYE53-invalid-error",
+    });
+  });
+});

--- a/nr-app/src/utils/event.utils.test.ts
+++ b/nr-app/src/utils/event.utils.test.ts
@@ -1,0 +1,64 @@
+import {
+  MAP_NOTE_KIND,
+  MAP_NOTE_REPOST_KIND,
+  NOTIFICATION_SUBSCRIPTION_KIND,
+  OPEN_LOCATION_CODE_LABEL_NAMESPACE,
+  TRUSTROOTS_PROFILE_KIND,
+} from "@trustroots/nr-common";
+
+import {
+  getKindName,
+  getPlusCodeFromEvent,
+  isEventForPlusCodeExactly,
+  isEventWithinThisPlusCode,
+} from "./event.utils";
+
+function eventWithPlusCode(plusCode?: string) {
+  return {
+    content: "",
+    created_at: 1,
+    id: "0".repeat(64),
+    kind: MAP_NOTE_REPOST_KIND,
+    pubkey: "1".repeat(64),
+    sig: "2".repeat(128),
+    tags: plusCode
+      ? [
+          ["L", OPEN_LOCATION_CODE_LABEL_NAMESPACE],
+          ["l", plusCode, OPEN_LOCATION_CODE_LABEL_NAMESPACE],
+        ]
+      : [],
+  };
+}
+
+describe("event.utils", () => {
+  it("extracts plus codes from labeled events", () => {
+    expect(getPlusCodeFromEvent(eventWithPlusCode("9F4G0000+"))).toBe(
+      "9F4G0000+",
+    );
+  });
+
+  it("detects exact plus-code matches", () => {
+    expect(
+      isEventForPlusCodeExactly(eventWithPlusCode("9F4G0000+"), "9F4G0000+"),
+    ).toBe(true);
+  });
+
+  it("detects child events within a parent plus code", () => {
+    expect(
+      isEventWithinThisPlusCode(eventWithPlusCode("9F4G9Q00+"), "9F4G0000+"),
+    ).toBe(true);
+    expect(isEventWithinThisPlusCode(eventWithPlusCode(), "9F4G0000+")).toBe(
+      false,
+    );
+  });
+
+  it.each([
+    [TRUSTROOTS_PROFILE_KIND, "Trustroots Profile"],
+    [NOTIFICATION_SUBSCRIPTION_KIND, "Notification Subscription"],
+    [MAP_NOTE_KIND, "Map Note"],
+    [MAP_NOTE_REPOST_KIND, "Map Note Repost"],
+    [123, "Unknown Kind (123)"],
+  ])("names kind %s", (kind, name) => {
+    expect(getKindName(kind)).toBe(name);
+  });
+});

--- a/nr-app/src/utils/location.test.ts
+++ b/nr-app/src/utils/location.test.ts
@@ -1,0 +1,31 @@
+import * as Location from "expo-location";
+import { getCurrentLocation } from "./location";
+
+describe("location", () => {
+  it("returns null when permission is denied", async () => {
+    (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue(
+      {
+        status: "denied",
+      },
+    );
+
+    await expect(getCurrentLocation()).resolves.toBeNull();
+  });
+
+  it("returns current position when permission is granted", async () => {
+    const location = {
+      coords: {
+        latitude: 52.52,
+        longitude: 13.405,
+      },
+    };
+    (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue(
+      {
+        status: "granted",
+      },
+    );
+    (Location.getCurrentPositionAsync as jest.Mock).mockResolvedValue(location);
+
+    await expect(getCurrentLocation()).resolves.toBe(location);
+  });
+});

--- a/nr-app/src/utils/map.utils.test.ts
+++ b/nr-app/src/utils/map.utils.test.ts
@@ -1,9 +1,56 @@
 import {
+  allPlusCodesForRegion,
+  arePlusCodesTheSameLength,
+  boundariesToRegion,
+  coordinatesToPlusCode,
+  filterEventsForPlusCode,
   getAllChildPlusCodes,
+  getAllPlusCodesBetweenTwoPlusCodes,
+  getEventLinkUrl,
+  getLayerForEvent,
+  getMapLayer,
   isPlusCodeBetweenTwoPlusCodes,
+  isValidPlusCode,
+  plusCodeToArrayPairs,
+  plusCodeToCoordinates,
   plusCodeHasTrailingZeroes,
   plusCodeToFirstFourSegments,
+  plusCodeToRectangle,
+  regionToBoundingBox,
 } from "./map.utils";
+import { MAP_LAYERS } from "@trustroots/nr-common";
+import type { EventWithMetadata } from "@/redux/slices/events.slice";
+
+function eventWith({
+  kind = 30397,
+  plusCode,
+  pubkey = "1".repeat(64),
+  tags = [],
+}: {
+  kind?: number;
+  plusCode?: string;
+  pubkey?: string;
+  tags?: string[][];
+} = {}): EventWithMetadata {
+  return {
+    event: {
+      content: "",
+      created_at: 1,
+      id: "0".repeat(64),
+      kind,
+      pubkey,
+      sig: "2".repeat(128),
+      tags: plusCode
+        ? [
+            ["L", "open-location-code"],
+            ["l", plusCode, "open-location-code"],
+            ...tags,
+          ]
+        : tags,
+    },
+    metadata: { seenOnRelays: [] },
+  };
+}
 
 describe("map.utils", () => {
   describe("plusCodeToFirstFourSegments()", () => {
@@ -21,6 +68,57 @@ describe("map.utils", () => {
     });
   });
 
+  it("validates, encodes, and splits plus codes", () => {
+    const berlin = coordinatesToPlusCode({
+      latitude: 52.52,
+      longitude: 13.405,
+      length: 8,
+    });
+
+    expect(isValidPlusCode(berlin)).toBe(true);
+    expect(isValidPlusCode("not-a-plus-code")).toBe(false);
+    expect(plusCodeToArrayPairs("23456789+")).toEqual([
+      ["2", "3"],
+      ["4", "5"],
+      ["6", "7"],
+      ["8", "9"],
+    ]);
+    expect(plusCodeToArrayPairs("9F4G0000+")).toEqual([
+      ["9", "F"],
+      ["4", "G"],
+    ]);
+    expect(() => plusCodeToArrayPairs("23456789+AB")).toThrow(
+      "Cannot split plus codes with values after the plus",
+    );
+  });
+
+  it("decodes plus codes into coordinates and rectangles", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation();
+    const coordinates = plusCodeToCoordinates("9F4MGCG4+");
+    const rectangle = plusCodeToRectangle("9F4MGCG4+");
+
+    expect(coordinates).toEqual(rectangle[2]);
+    expect(rectangle).toHaveLength(4);
+    expect(rectangle[0].latitude).toBeLessThan(rectangle[1].latitude);
+    expect(rectangle[0].longitude).toBeLessThan(rectangle[2].longitude);
+    expect(() => plusCodeToCoordinates("invalid")).toThrow();
+    expect(() => plusCodeToRectangle("invalid")).toThrow();
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("covers a visible region with valid plus-code prefixes", () => {
+    const codes = allPlusCodesForRegion({
+      latitude: 52.52,
+      latitudeDelta: 0.01,
+      longitude: 13.405,
+      longitudeDelta: 0.01,
+      codeLength: 6,
+    });
+
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.every(isValidPlusCode)).toBe(true);
+  });
+
   describe("plusCodeHasTrailingZeroes()", () => {
     it("returns false for a single zero", () => {
       expect(plusCodeHasTrailingZeroes("7FG49QG0+")).toEqual(false);
@@ -31,6 +129,11 @@ describe("map.utils", () => {
     it("returns false for trailing digits", () => {
       expect(plusCodeHasTrailingZeroes("7FG49QGA+FF")).toEqual(false);
       expect(plusCodeHasTrailingZeroes("7FG49QGA+FFF")).toEqual(false);
+    });
+
+    it("returns false for invalid and full-length codes", () => {
+      expect(plusCodeHasTrailingZeroes("00000000+")).toBe(false);
+      expect(plusCodeHasTrailingZeroes("23456789+")).toBe(false);
     });
 
     it("returns true for trailing zeroes", () => {
@@ -52,6 +155,12 @@ describe("map.utils", () => {
         isPlusCodeBetweenTwoPlusCodes("9F5G2G5Q+", "9F4F8QP5+", "9F4GP647+"),
       ).toEqual(true);
     });
+
+    it("returns false when the target is outside the corners", () => {
+      expect(
+        isPlusCodeBetweenTwoPlusCodes("9F5G2G5Q+", "9F4F8QP5+", "8FVC9G8F+"),
+      ).toBe(false);
+    });
   });
 
   describe("getAllChildPlusCodes()", () => {
@@ -61,5 +170,100 @@ describe("map.utils", () => {
       expect(children[0]).toBe("7FG49Q22+");
       expect(children[children.length - 1]).toBe("7FG49QXX+");
     });
+
+    it("rejects codes that do not identify a parent area", () => {
+      expect(() => getAllChildPlusCodes("9F4MGCG4+")).toThrow(
+        "#g4qh7N-invalid-plus-code",
+      );
+    });
+  });
+
+  it("looks up map layers and builds external event links", () => {
+    const hitchwiki = getMapLayer("hitchwiki");
+    const linkedEvent = eventWith({
+      tags: [["linkPath", "/places/berlin"]],
+    }).event;
+
+    expect(hitchwiki).toBe(MAP_LAYERS.hitchwiki);
+    expect(getMapLayer()).toBeUndefined();
+    expect(getMapLayer("missing")).toBeUndefined();
+    expect(getEventLinkUrl(linkedEvent, hitchwiki)).toBe(
+      "https://hitchwiki.org/places/berlin",
+    );
+    expect(getEventLinkUrl(linkedEvent)).toBeUndefined();
+    expect(getEventLinkUrl(eventWith().event, hitchwiki)).toBeUndefined();
+  });
+
+  it("converts between regions and padded map boundaries", () => {
+    const boundaries = regionToBoundingBox({
+      latitude: 10,
+      longitude: 20,
+      latitudeDelta: 2,
+      longitudeDelta: 4,
+    });
+
+    expect(boundaries).toEqual({
+      northEast: { latitude: 12, longitude: 23 },
+      southWest: { latitude: 8, longitude: 17 },
+    });
+    expect(boundariesToRegion(boundaries)).toEqual({
+      latitude: 10,
+      longitude: 20,
+      latitudeDelta: 4,
+      longitudeDelta: 6,
+    });
+  });
+
+  it("compares plus-code precision", () => {
+    expect(arePlusCodesTheSameLength("9F4G0000+", "8FVC0000+")).toBe(true);
+    expect(arePlusCodesTheSameLength("9F4MGCG4+", "8FVC9G8F+")).toBe(true);
+    expect(arePlusCodesTheSameLength("9F4G0000+", "9F4MGCG4+")).toBe(false);
+    expect(arePlusCodesTheSameLength("9F4G0000+", "9F4MG000+")).toBe(false);
+  });
+
+  it.each([2, 4, 6, 8] as const)(
+    "enumerates plus-code cells at precision %s",
+    (length) => {
+      const codes = getAllPlusCodesBetweenTwoPlusCodes(
+        "9F4MGCG4+",
+        "9F4MGCG4+",
+        length,
+      );
+
+      expect(codes.length).toBeGreaterThan(0);
+      expect(codes.every(isValidPlusCode)).toBe(true);
+    },
+  );
+
+  it("rejects overlong boundaries", () => {
+    expect(() =>
+      getAllPlusCodesBetweenTwoPlusCodes("9F4MGCG4+5X", "9F4MGCG4+", 8),
+    ).toThrow("#w2RUhg-plus-code-too-long");
+  });
+
+  it("separates exact, child, and unrelated map events", () => {
+    const exact = eventWith({ plusCode: "9F4G0000+" });
+    const child = eventWith({ plusCode: "9F4G9Q00+" });
+    const unrelated = eventWith({ plusCode: "8FVC0000+" });
+
+    expect(
+      filterEventsForPlusCode([exact, child, unrelated], "9F4G0000+"),
+    ).toEqual({
+      eventsForPlusCodeExactly: [exact],
+      eventsWithinPlusCode: [child],
+    });
+  });
+
+  it("identifies configured layers and falls back for unknown events", () => {
+    expect(
+      getLayerForEvent(
+        eventWith({
+          kind: MAP_LAYERS.hitchwiki.kind,
+          pubkey: MAP_LAYERS.hitchwiki.pubkey,
+        }).event,
+      ),
+    ).toBe("hitchwiki");
+    expect(getLayerForEvent(eventWith().event)).toBe("unverified");
+    expect(getLayerForEvent(eventWith({ kind: 1 }).event)).toBe("trustroots");
   });
 });

--- a/nr-app/src/utils/navigation.utils.test.ts
+++ b/nr-app/src/utils/navigation.utils.test.ts
@@ -1,0 +1,46 @@
+import { getRouterMock } from "@/test/router";
+import { ROUTES } from "@/constants/routes";
+import { addEvent } from "@/redux/slices/events.slice";
+import { mapActions } from "@/redux/slices/map.slice";
+import {
+  configureNavigationDispatch,
+  navigateToEvent,
+} from "./navigation.utils";
+
+jest.mock("./map.utils", () => ({
+  getLayerForEvent: jest.fn(() => "trustroots"),
+  plusCodeToCoordinates: jest.fn(() => ({
+    latitude: 52.52,
+    longitude: 13.405,
+  })),
+}));
+
+describe("navigation.utils", () => {
+  it("dispatches map actions and routes home for events", () => {
+    const dispatch = jest.fn();
+    const event = {
+      content: "",
+      created_at: 1,
+      id: "0".repeat(64),
+      kind: 1,
+      pubkey: "1".repeat(64),
+      sig: "2".repeat(128),
+      tags: [],
+    };
+
+    configureNavigationDispatch(dispatch);
+    navigateToEvent("9F4G0000+", event);
+
+    expect(dispatch).toHaveBeenCalledWith(mapActions.enableLayer("trustroots"));
+    expect(dispatch).toHaveBeenCalledWith(
+      addEvent({ event, fromRelay: "notification" }),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      mapActions.setCurrentMapLocation({
+        latitude: 52.52,
+        longitude: 13.405,
+      }),
+    );
+    expect(getRouterMock().dismissTo).toHaveBeenCalledWith(ROUTES.HOME);
+  });
+});

--- a/nr-app/src/utils/notifications.utils.test.ts
+++ b/nr-app/src/utils/notifications.utils.test.ts
@@ -1,0 +1,49 @@
+import {
+  addFilterToFiltersArray,
+  doesFilterMatchParentPlusCode,
+  doesFilterMatchPlusCodeExactly,
+  filterForPlusCode,
+  removeFilterFromFiltersArray,
+} from "./notifications.utils";
+
+describe("notifications.utils", () => {
+  it("adds filters without duplicates", () => {
+    const filter = { filter: { kinds: [1] } };
+
+    expect(addFilterToFiltersArray([], filter)).toEqual([filter]);
+    expect(addFilterToFiltersArray([filter], filter)).toEqual([filter]);
+  });
+
+  it("removes matching filters", () => {
+    const filter = { filter: { kinds: [1] } };
+    const otherFilter = { filter: { kinds: [2] } };
+
+    expect(removeFilterFromFiltersArray([filter, otherFilter], filter)).toEqual(
+      [otherFilter],
+    );
+  });
+
+  it("builds map-note filters for plus codes", () => {
+    expect(filterForPlusCode("9F4G0000+")).toMatchObject({
+      "#l": ["9F4G0000+"],
+    });
+  });
+
+  it("matches exact plus-code labels", () => {
+    expect(
+      doesFilterMatchPlusCodeExactly({ "#l": ["9F4G0000+"] }, "9F4G0000+"),
+    ).toBe(true);
+    expect(doesFilterMatchPlusCodeExactly({ kinds: [1] }, "9F4G0000+")).toBe(
+      false,
+    );
+  });
+
+  it("matches parent plus-code labels", () => {
+    expect(
+      doesFilterMatchParentPlusCode({ "#l": ["9F4G0000+"] }, "9F4G9Q00+"),
+    ).toBe(true);
+    expect(doesFilterMatchParentPlusCode({ kinds: [1] }, "9F4G9Q00+")).toBe(
+      false,
+    );
+  });
+});

--- a/nr-app/tsconfig.json
+++ b/nr-app/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "types": ["jest", "node"],
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
     "app:start": "pnpm --filter nr-app start",
     "postinstall": "patch-package",
     "test": "pnpm test:app && pnpm test:common",
-    "test:watch": "pnpm --filter nr-app test",
+    "test:watch": "pnpm --filter nr-app test:watch",
     "test:app": "pnpm --filter nr-app test",
+    "test:app:ci": "pnpm --filter nr-app test:ci",
+    "test:app:coverage": "pnpm --filter nr-app test:coverage",
+    "typecheck:app": "pnpm --filter nr-app typecheck",
     "test:common": "cd nr-common && deno task test"
   }
 }


### PR DESCRIPTION
## Summary

- establish a reusable Jest/RNTL test harness for nr-app
- add focused coverage for components, routes, Redux state, sagas, Nostr helpers, and services
- publish a coverage overview and downloadable report on nr-app pull requests
- enforce coverage floors of 61% statements, 51% branches, 55% functions, and 62% lines

## Why

nr-app had limited automated coverage and repeated native-module setup across tests. This adds deterministic shared mocks and render helpers so core behavior can be tested quickly without depending on the native E2E stack.

The Maestro/native E2E work remains in #227 and is intentionally excluded from this PR.

## Developer impact

- `pnpm --dir nr-app test:ci` runs the CI coverage suite
- `pnpm --dir nr-app test:coverage` produces a local coverage report
- nr-app PRs receive an automatically updated Jest/coverage table

## Validation

- 65 Jest suites passed
- 305 tests passed
- statements: 62.14%
- branches: 52.43%
- functions: 56.25%
- lines: 62.92%
