### PR TITLE
fix(nr-app): clarify onboarding copy and harden backup confirmation

### DIFF
--- a/nr-app/.maestro/README.md
+++ b/nr-app/.maestro/README.md
@@ -67,7 +67,7 @@ key step.
 `app/onboarding/trustroots.tsx` is the primary onboarding branch. It requests a
 six-digit code through `nr-bridge` and delivers it by email, so it cannot be
 driven end to end without a mock bridge. The flows take the legacy key path
-instead (`I've already set my key on Trustroots`).
+instead (`Set up my key manually`).
 
 Both flows stop at the link screen. `link.tsx` gates its Finish button on a live
 NIP-05 lookup against trustroots.org that must match the local npub, so reaching

--- a/nr-app/.maestro/flows/onboarding-generate.yaml
+++ b/nr-app/.maestro/flows/onboarding-generate.yaml
@@ -13,9 +13,22 @@ name: Onboarding - generate a new key
     id: "onboarding-key-mnemonic-input"
     text: "(\\w+ ){11}\\w+"
 
+- copyTextFrom:
+    id: "onboarding-key-mnemonic-input"
+- evaluateScript: ${output.words = maestro.copiedText.trim().split(/\s+/)}
+
 - tapOn:
     id: "onboarding-key-mnemonic-confirm"
-- assertVisible: "Saved"
+
+# The words are hidden now; the challenge asks for three of them by position.
+- runFlow:
+    file: ../subflows/answer-backup-challenge.yaml
+    env:
+      PREFIX: "onboarding-key-backup"
+
+- tapOn:
+    id: "onboarding-key-backup-confirm"
+- assertVisible: "Backup confirmed"
 
 - tapOn:
     id: "onboarding-key-continue"

--- a/nr-app/.maestro/flows/onboarding-import.yaml
+++ b/nr-app/.maestro/flows/onboarding-import.yaml
@@ -14,7 +14,7 @@ env:
     id: "onboarding-key-import-input"
 - inputText: ${TEST_NSEC}
 # hideKeyboard does not work against this input; tap inert copy to dismiss.
-- tapOn: "Import Your Trustroots Key"
+- tapOn: "Set Up Your Key"
 
 - tapOn:
     id: "onboarding-key-import-save"

--- a/nr-app/.maestro/subflows/answer-backup-challenge.yaml
+++ b/nr-app/.maestro/subflows/answer-backup-challenge.yaml
@@ -1,0 +1,100 @@
+appId: org.trustroots.nostroots
+name: Answer the backup challenge
+# Requires: output.words (the 12-word mnemonic) and PREFIX (testID prefix).
+---
+- runFlow:
+    when:
+      visible: "Word 1"
+    commands:
+      - tapOn:
+          id: "${PREFIX}-word-1"
+      - inputText: ${output.words[0]}
+      - hideKeyboard
+- runFlow:
+    when:
+      visible: "Word 2"
+    commands:
+      - tapOn:
+          id: "${PREFIX}-word-2"
+      - inputText: ${output.words[1]}
+      - hideKeyboard
+- runFlow:
+    when:
+      visible: "Word 3"
+    commands:
+      - tapOn:
+          id: "${PREFIX}-word-3"
+      - inputText: ${output.words[2]}
+      - hideKeyboard
+- runFlow:
+    when:
+      visible: "Word 4"
+    commands:
+      - tapOn:
+          id: "${PREFIX}-word-4"
+      - inputText: ${output.words[3]}
+      - hideKeyboard
+- runFlow:
+    when:
+      visible: "Word 5"
+    commands:
+      - tapOn:
+          id: "${PREFIX}-word-5"
+      - inputText: ${output.words[4]}
+      - hideKeyboard
+- runFlow:
+    when:
+      visible: "Word 6"
+    commands:
+      - tapOn:
+          id: "${PREFIX}-word-6"
+      - inputText: ${output.words[5]}
+      - hideKeyboard
+- runFlow:
+    when:
+      visible: "Word 7"
+    commands:
+      - tapOn:
+          id: "${PREFIX}-word-7"
+      - inputText: ${output.words[6]}
+      - hideKeyboard
+- runFlow:
+    when:
+      visible: "Word 8"
+    commands:
+      - tapOn:
+          id: "${PREFIX}-word-8"
+      - inputText: ${output.words[7]}
+      - hideKeyboard
+- runFlow:
+    when:
+      visible: "Word 9"
+    commands:
+      - tapOn:
+          id: "${PREFIX}-word-9"
+      - inputText: ${output.words[8]}
+      - hideKeyboard
+- runFlow:
+    when:
+      visible: "Word 10"
+    commands:
+      - tapOn:
+          id: "${PREFIX}-word-10"
+      - inputText: ${output.words[9]}
+      - hideKeyboard
+- runFlow:
+    when:
+      visible: "Word 11"
+    commands:
+      - tapOn:
+          id: "${PREFIX}-word-11"
+      - inputText: ${output.words[10]}
+      - hideKeyboard
+- runFlow:
+    when:
+      visible: "Word 12"
+    commands:
+      - tapOn:
+          id: "${PREFIX}-word-12"
+      - inputText: ${output.words[11]}
+      - hideKeyboard

--- a/nr-app/app/onboarding/_layout.tsx
+++ b/nr-app/app/onboarding/_layout.tsx
@@ -15,7 +15,7 @@ const routeStepMap: Record<string, string> = {
   identity: "identity",
   trustroots: "trustroots",
   key: "trustroots",
-  link: "trustroots",
+  link: "backup-confirm",
   "backup-confirm": "backup-confirm",
 };
 

--- a/nr-app/app/onboarding/backup-confirm.tsx
+++ b/nr-app/app/onboarding/backup-confirm.tsx
@@ -1,9 +1,7 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
-import * as Clipboard from "expo-clipboard";
 import { ShieldCheckIcon } from "lucide-react-native";
 import React, { useEffect, useState } from "react";
 import { TextInput, View } from "react-native";
-import Toast from "react-native-root-toast";
 
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
@@ -86,6 +84,7 @@ export default function OnboardingBackupConfirmScreen() {
   const [isVerifying, setIsVerifying] = useState(false);
   const [setupError, setSetupError] = useState<string | null>(null);
   const [storedSecret, setStoredSecret] = useState<string | null>(null);
+  const [secretAcknowledged, setSecretAcknowledged] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -199,18 +198,14 @@ export default function OnboardingBackupConfirmScreen() {
     );
   };
 
-  const handleCopySecret = async () => {
-    if (!storedSecret) return;
+  const isRevealStep = !!storedSecret && !secretAcknowledged;
 
-    try {
-      await Clipboard.setStringAsync(storedSecret);
-      Toast.show("Copied secret to Clipboard!", {
-        duration: Toast.durations.SHORT,
-        position: Toast.positions.BOTTOM,
-      });
-    } catch (error) {
-      console.error("Failed to copy secret", error);
-    }
+  const handleAcknowledgeSecret = () => {
+    trackEvent("onboarding_backup", {
+      action: "secret_acknowledged",
+      source: from === "bridge" ? "bridge" : "legacy_key",
+    });
+    setSecretAcknowledged(true);
   };
 
   const isConfirmDisabled =
@@ -231,75 +226,83 @@ export default function OnboardingBackupConfirmScreen() {
           if you lose it.
         </Text>
         <Text variant="p">
-          Re-enter your nsec or your 12/24-word mnemonic to confirm you’ve saved
-          it safely.
+          {isRevealStep
+            ? "Write it down or store it in a password manager. On the next step you type it back in from your backup."
+            : "Type your secret back in from your backup to confirm you’ve saved it safely."}
         </Text>
       </View>
 
-      {storedSecret && (
-        <View className="w-full gap-2 bg-card rounded-lg p-3">
-          <Text className="text-sm font-bold text-foreground text-left">
-            Save this secret before continuing
-          </Text>
-          <Text
-            className="text-sm bg-muted text-foreground rounded-md p-3 text-left"
-            selectable
-          >
-            {storedSecret}
-          </Text>
+      {isRevealStep ? (
+        <>
+          <View className="w-full gap-2 bg-card rounded-lg p-3">
+            <Text className="text-sm font-bold text-foreground text-left">
+              Save this secret before continuing
+            </Text>
+            <Text
+              testID="onboarding-backup-secret"
+              className="text-sm bg-muted text-foreground rounded-md p-3 text-left"
+            >
+              {storedSecret}
+            </Text>
+          </View>
           <Button
-            variant="outline"
-            size="sm"
-            title="Copy secret"
-            onPress={handleCopySecret}
+            testID="onboarding-backup-secret-saved"
+            variant="secondary"
+            size="lg"
+            title="I have saved my secret"
+            onPress={handleAcknowledgeSecret}
           />
-        </View>
+        </>
+      ) : (
+        <>
+          <View className="w-full gap-2">
+            <TextInput
+              value={input}
+              onChangeText={(value) => {
+                setInput(value);
+                setError(null);
+                setSuccess(false);
+              }}
+              placeholder="Type your 12/24-word mnemonic or nsec1... key"
+              placeholderTextColor="#6b7280"
+              autoCapitalize="none"
+              autoCorrect={false}
+              multiline
+              className="w-full bg-card text-foreground rounded-md p-3 text-sm min-h-[72px]"
+            />
+
+            {error && (
+              <Text className="text-xs text-red-500 mt-1">{error}</Text>
+            )}
+
+            {setupError && (
+              <Text className="text-xs text-red-500 mt-1 text-left">
+                {setupError}
+              </Text>
+            )}
+
+            {success && !error && (
+              <Text className="text-xs text-green-400 mt-1">
+                You’re all set — backup confirmed.
+              </Text>
+            )}
+          </View>
+
+          <Button
+            variant="secondary"
+            size="lg"
+            title={
+              success
+                ? "Backup confirmed"
+                : isVerifying
+                  ? "Confirming..."
+                  : "Confirm backup"
+            }
+            disabled={isConfirmDisabled}
+            onPress={handleConfirm}
+          />
+        </>
       )}
-
-      <View className="w-full gap-2">
-        <TextInput
-          value={input}
-          onChangeText={(value) => {
-            setInput(value);
-            setError(null);
-            setSuccess(false);
-          }}
-          placeholder="Paste your nsec1... key or type your 12/24-word mnemonic"
-          placeholderTextColor="#6b7280"
-          autoCapitalize="none"
-          autoCorrect={false}
-          multiline
-          className="w-full bg-card text-foreground rounded-md p-3 text-sm min-h-[72px]"
-        />
-
-        {error && <Text className="text-xs text-red-500 mt-1">{error}</Text>}
-
-        {setupError && (
-          <Text className="text-xs text-red-500 mt-1 text-left">
-            {setupError}
-          </Text>
-        )}
-
-        {success && !error && (
-          <Text className="text-xs text-green-400 mt-1">
-            You’re all set — backup confirmed.
-          </Text>
-        )}
-      </View>
-
-      <Button
-        variant="secondary"
-        size="lg"
-        title={
-          success
-            ? "Backup confirmed"
-            : isVerifying
-              ? "Confirming..."
-              : "Confirm backup"
-        }
-        disabled={isConfirmDisabled}
-        onPress={handleConfirm}
-      />
 
       <View className="flex flex-row gap-2 mt-4">
         <Button

--- a/nr-app/app/onboarding/backup-confirm.tsx
+++ b/nr-app/app/onboarding/backup-confirm.tsx
@@ -1,8 +1,9 @@
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { useRouter } from "expo-router";
 import { ShieldCheckIcon } from "lucide-react-native";
 import React, { useEffect, useState } from "react";
-import { TextInput, View } from "react-native";
+import { View } from "react-native";
 
+import { BackupChallenge } from "@/components/BackupChallenge";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { ROUTES } from "@/constants/routes";
@@ -12,113 +13,46 @@ import {
   getPrivateKeyHexFromSecureStorage,
   getPrivateKeyMnemonicFromSecureStorage,
 } from "@/nostr/keystore.nostr";
-import { useAppSelector } from "@/redux/hooks";
-import { settingsSelectors } from "@/redux/slices/settings.slice";
 import { getBech32PrivateKey } from "nip06";
 import { trackEvent } from "@/services/analytics.service";
 
-async function verifyBackupInput(rawInput: string): Promise<boolean> {
-  const input = rawInput.trim();
-  if (!input) return false;
-
-  let expectedNsec: string | null = null;
-  let expectedMnemonic: string | null = null;
-
-  const hasHex = await getHasPrivateKeyHexInSecureStorage();
-  if (hasHex) {
-    const privateKey = await getPrivateKeyHexFromSecureStorage();
-    try {
-      const { bech32PrivateKey: nsec } = getBech32PrivateKey({ privateKey });
-      expectedNsec = nsec;
-    } catch {
-      expectedNsec = null;
-    }
-  }
-
-  try {
-    const hasMnemonic = await getHasPrivateKeyMnemonicInSecureStorage();
-    if (hasMnemonic) {
-      const storedMnemonic = await getPrivateKeyMnemonicFromSecureStorage();
-      const normalizedStored = storedMnemonic
-        .trim()
-        .split(/\s+/)
-        .join(" ")
-        .toLowerCase();
-      if (normalizedStored.length > 0) {
-        expectedMnemonic = normalizedStored;
-      }
-    }
-  } catch {
-    // ignore, handled via null checks
-  }
-
-  if (!expectedNsec && !expectedMnemonic) {
-    return false;
-  }
-
-  if (input.toLowerCase().startsWith("nsec1")) {
-    const candidateNsec = input.trim().toLowerCase();
-    if (expectedNsec && candidateNsec === expectedNsec.toLowerCase()) {
-      return true;
-    }
-    return false;
-  }
-
-  const candidateMnemonic = input.trim().split(/\s+/).join(" ").toLowerCase();
-
-  if (expectedMnemonic && candidateMnemonic === expectedMnemonic) {
-    return true;
-  }
-
-  return false;
-}
-
 export default function OnboardingBackupConfirmScreen() {
   const router = useRouter();
-  const { from } = useLocalSearchParams<{ from?: string }>();
-  const keyWasImported = useAppSelector(settingsSelectors.selectKeyWasImported);
 
-  const [input, setInput] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
-  const [isVerifying, setIsVerifying] = useState(false);
-  const [setupError, setSetupError] = useState<string | null>(null);
-  const [storedSecret, setStoredSecret] = useState<string | null>(null);
+  const [secret, setSecret] = useState<string | null>(null);
   const [secretAcknowledged, setSecretAcknowledged] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+  const [setupError, setSetupError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
 
-    async function checkSecrets() {
+    async function loadSecret() {
       try {
         const [hasHex, hasMnemonic] = await Promise.all([
           getHasPrivateKeyHexInSecureStorage(),
           getHasPrivateKeyMnemonicInSecureStorage(),
         ]);
 
-        if (!hasHex && !hasMnemonic) {
-          if (!cancelled) {
-            setSetupError(
-              "We could not find your key on this device. Please restart onboarding.",
-            );
-          }
-        } else if (!keyWasImported) {
-          let secret: string | null = null;
+        let loaded: string | null = null;
 
-          if (hasMnemonic) {
-            secret = await getPrivateKeyMnemonicFromSecureStorage();
-          } else if (hasHex) {
-            const privateKey = await getPrivateKeyHexFromSecureStorage();
-            const { bech32PrivateKey: nsec } = getBech32PrivateKey({
-              privateKey,
-            });
-            secret = nsec;
-          }
-
-          if (!cancelled) {
-            setStoredSecret(secret);
-          }
+        if (hasMnemonic) {
+          loaded = await getPrivateKeyMnemonicFromSecureStorage();
+        } else if (hasHex) {
+          const privateKey = await getPrivateKeyHexFromSecureStorage();
+          loaded = getBech32PrivateKey({ privateKey }).bech32PrivateKey;
         }
+
+        if (cancelled) return;
+
+        if (!loaded) {
+          setSetupError(
+            "We could not find your key on this device. Please restart onboarding.",
+          );
+          return;
+        }
+
+        setSecret(loaded);
       } catch {
         if (!cancelled) {
           setSetupError(
@@ -128,95 +62,55 @@ export default function OnboardingBackupConfirmScreen() {
       }
     }
 
-    checkSecrets();
+    loadSecret();
 
     return () => {
       cancelled = true;
-      setError(null);
-      setSuccess(false);
     };
-  }, [keyWasImported]);
-
-  const handleConfirm = async () => {
-    if (setupError) return;
-
-    const trimmed = input.trim();
-    if (!trimmed) {
-      setError("Enter your nsec or mnemonic to confirm your backup.");
-      setSuccess(false);
-      return;
-    }
-
-    setIsVerifying(true);
-    setError(null);
-
-    try {
-      const ok = await verifyBackupInput(trimmed);
-      if (!ok) {
-        trackEvent("onboarding_backup_confirmed", {
-          outcome: "mismatch",
-          source: from === "bridge" ? "bridge" : "legacy_key",
-        });
-        setSuccess(false);
-        setError(
-          "That does not match your saved secret. Double-check and try again.",
-        );
-      } else {
-        trackEvent("onboarding_backup_confirmed", {
-          outcome: "success",
-          source: from === "bridge" ? "bridge" : "legacy_key",
-        });
-        setSuccess(true);
-        setError(null);
-        setInput("");
-      }
-    } finally {
-      setIsVerifying(false);
-    }
-  };
-
-  const handleFinish = () => {
-    if (!success) return;
-    trackEvent("onboarding_completed", {
-      method: from === "bridge" ? "bridge" : "generated_key",
-    });
-    setInput("");
-    setError(null);
-    router.replace(ROUTES.HOME);
-  };
-
-  const handleBack = () => {
-    trackEvent("onboarding_backup", {
-      action: "back",
-      source: from === "bridge" ? "bridge" : "legacy_key",
-    });
-    setInput("");
-    setError(null);
-    setSuccess(false);
-    router.dismissTo(
-      from === "bridge" ? "/onboarding/trustroots" : "/onboarding/key",
-    );
-  };
-
-  const isRevealStep = !!storedSecret && !secretAcknowledged;
+  }, []);
 
   const handleAcknowledgeSecret = () => {
     trackEvent("onboarding_backup", {
       action: "secret_acknowledged",
-      source: from === "bridge" ? "bridge" : "legacy_key",
+      source: "bridge",
     });
     setSecretAcknowledged(true);
   };
 
-  const isConfirmDisabled =
-    !!setupError || isVerifying || success || !input.trim().length;
+  const handleConfirmed = () => {
+    trackEvent("onboarding_backup_confirmed", {
+      outcome: "success",
+      source: "bridge",
+    });
+    setConfirmed(true);
+  };
+
+  const handleFailed = () => {
+    trackEvent("onboarding_backup_confirmed", {
+      outcome: "mismatch",
+      source: "bridge",
+    });
+  };
+
+  const handleFinish = () => {
+    if (!confirmed) return;
+    trackEvent("onboarding_completed", { method: "bridge" });
+    router.replace(ROUTES.HOME);
+  };
+
+  const handleBack = () => {
+    trackEvent("onboarding_backup", { action: "back", source: "bridge" });
+    router.dismissTo("/onboarding/trustroots");
+  };
+
+  const isRevealStep = !secretAcknowledged;
 
   return (
     <>
       <View className="flex items-center gap-6">
         <ShieldCheckIcon size={128} color="#fff" strokeWidth={0.5} />
         <Text variant="h1" className="my-0">
-          Confirm Your Backup
+          Save Your Key
         </Text>
       </View>
 
@@ -227,22 +121,27 @@ export default function OnboardingBackupConfirmScreen() {
         </Text>
         <Text variant="p">
           {isRevealStep
-            ? "Write it down or store it in a password manager. On the next step you type it back in from your backup."
-            : "Type your secret back in from your backup to confirm you’ve saved it safely."}
+            ? "Write it down or store it in a password manager. Then we ask you for a few parts of it, to check it really is saved."
+            : "Now check your backup — we only ask for a few parts of it."}
         </Text>
       </View>
 
-      {isRevealStep ? (
+      {setupError && (
+        <Text className="text-xs text-red-500 text-left">{setupError}</Text>
+      )}
+
+      {secret && isRevealStep && (
         <>
           <View className="w-full gap-2 bg-card rounded-lg p-3">
             <Text className="text-sm font-bold text-foreground text-left">
-              Save this secret before continuing
+              Your secret
             </Text>
             <Text
               testID="onboarding-backup-secret"
               className="text-sm bg-muted text-foreground rounded-md p-3 text-left"
+              selectable
             >
-              {storedSecret}
+              {secret}
             </Text>
           </View>
           <Button
@@ -253,55 +152,17 @@ export default function OnboardingBackupConfirmScreen() {
             onPress={handleAcknowledgeSecret}
           />
         </>
-      ) : (
-        <>
-          <View className="w-full gap-2">
-            <TextInput
-              value={input}
-              onChangeText={(value) => {
-                setInput(value);
-                setError(null);
-                setSuccess(false);
-              }}
-              placeholder="Type your 12/24-word mnemonic or nsec1... key"
-              placeholderTextColor="#6b7280"
-              autoCapitalize="none"
-              autoCorrect={false}
-              multiline
-              className="w-full bg-card text-foreground rounded-md p-3 text-sm min-h-[72px]"
-            />
+      )}
 
-            {error && (
-              <Text className="text-xs text-red-500 mt-1">{error}</Text>
-            )}
-
-            {setupError && (
-              <Text className="text-xs text-red-500 mt-1 text-left">
-                {setupError}
-              </Text>
-            )}
-
-            {success && !error && (
-              <Text className="text-xs text-green-400 mt-1">
-                You’re all set — backup confirmed.
-              </Text>
-            )}
-          </View>
-
-          <Button
-            variant="secondary"
-            size="lg"
-            title={
-              success
-                ? "Backup confirmed"
-                : isVerifying
-                  ? "Confirming..."
-                  : "Confirm backup"
-            }
-            disabled={isConfirmDisabled}
-            onPress={handleConfirm}
-          />
-        </>
+      {secret && !isRevealStep && (
+        <BackupChallenge
+          key={secret}
+          secret={secret}
+          confirmed={confirmed}
+          onConfirmed={handleConfirmed}
+          onFailed={handleFailed}
+          testIDPrefix="onboarding-backup"
+        />
       )}
 
       <View className="flex flex-row gap-2 mt-4">
@@ -313,11 +174,12 @@ export default function OnboardingBackupConfirmScreen() {
         />
 
         <Button
+          testID="onboarding-backup-finish"
           variant="secondary"
           size="lg"
           title="Finish"
           onPress={handleFinish}
-          disabled={!success}
+          disabled={!confirmed}
         />
       </View>
     </>

--- a/nr-app/app/onboarding/key.tsx
+++ b/nr-app/app/onboarding/key.tsx
@@ -2,6 +2,7 @@ import { useRouter } from "expo-router";
 import React, { useCallback, useEffect, useState } from "react";
 import { View } from "react-native";
 
+import { BackupChallenge } from "@/components/BackupChallenge";
 import { KeyInput } from "@/components/KeyInput";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -36,6 +37,7 @@ export default function OnboardingKeyScreen() {
   const [keySaved, setKeySaved] = useState(false);
 
   const [mnemonic, setMnemonic] = useState("");
+  const [mnemonicSaved, setMnemonicSaved] = useState(false);
   const [mnemonicConfirmed, setMnemonicConfirmed] = useState(false);
   const [mnemonicError, setMnemonicError] = useState<string | null>(null);
 
@@ -52,8 +54,33 @@ export default function OnboardingKeyScreen() {
   }, []);
 
   const handleRegenerateMnemonic = () => {
+    setMnemonicSaved(false);
     setMnemonicConfirmed(false);
     setMnemonicError(null);
+  };
+
+  const handleMnemonicSaved = () => {
+    trackEvent("onboarding_backup", {
+      action: "secret_acknowledged",
+      source: "legacy_key",
+    });
+    setMnemonicError(null);
+    setMnemonicSaved(true);
+  };
+
+  const handleMnemonicConfirmed = () => {
+    trackEvent("onboarding_backup_confirmed", {
+      outcome: "success",
+      source: "legacy_key",
+    });
+    setMnemonicConfirmed(true);
+  };
+
+  const handleMnemonicChallengeFailed = () => {
+    trackEvent("onboarding_backup_confirmed", {
+      outcome: "mismatch",
+      source: "legacy_key",
+    });
   };
 
   const saveExistingKey = async () => {
@@ -76,7 +103,9 @@ export default function OnboardingKeyScreen() {
 
   const saveGeneratedMnemonic = useCallback(async () => {
     if (!mnemonic || !mnemonicConfirmed) {
-      setMnemonicError("Please save and confirm your words before continuing.");
+      setMnemonicError(
+        "Please save your words and confirm them before continuing.",
+      );
       return;
     }
 
@@ -183,28 +212,48 @@ export default function OnboardingKeyScreen() {
               {mnemonicError && (
                 <Text className="text-xs text-red-500">{mnemonicError}</Text>
               )}
-              <KeyInput
-                testID="onboarding-key-mnemonic-input"
-                value={mnemonic}
-                onChangeText={setMnemonic}
-                placeholder=""
-                disabled={false}
-                generateMode={true}
-                showRegenerateButton={true}
-                onRegenerate={handleRegenerateMnemonic}
-                showCopyButton={true}
-              />
-              <Button
-                testID="onboarding-key-mnemonic-confirm"
-                size="lg"
-                title={
-                  mnemonicConfirmed
-                    ? "Saved"
-                    : "I have saved these words safely"
-                }
-                disabled={mnemonicConfirmed}
-                onPress={() => setMnemonicConfirmed(true)}
-              />
+              {mnemonicSaved ? (
+                <>
+                  <BackupChallenge
+                    key={mnemonic}
+                    secret={mnemonic}
+                    confirmed={mnemonicConfirmed}
+                    onConfirmed={handleMnemonicConfirmed}
+                    onFailed={handleMnemonicChallengeFailed}
+                    testIDPrefix="onboarding-key-backup"
+                  />
+                  {!mnemonicConfirmed && (
+                    <Button
+                      testID="onboarding-key-mnemonic-show-again"
+                      size="sm"
+                      variant="outline"
+                      title="Show my words again"
+                      onPress={() => setMnemonicSaved(false)}
+                    />
+                  )}
+                </>
+              ) : (
+                <>
+                  <KeyInput
+                    testID="onboarding-key-mnemonic-input"
+                    value={mnemonic}
+                    onChangeText={setMnemonic}
+                    placeholder=""
+                    disabled={false}
+                    generateMode={true}
+                    showRegenerateButton={true}
+                    onRegenerate={handleRegenerateMnemonic}
+                    showCopyButton={true}
+                  />
+                  <Button
+                    testID="onboarding-key-mnemonic-confirm"
+                    size="lg"
+                    title="I have saved these words safely"
+                    disabled={!mnemonic}
+                    onPress={handleMnemonicSaved}
+                  />
+                </>
+              )}
             </TabsContent>
           </TextClassContext.Provider>
         </Tabs>

--- a/nr-app/app/onboarding/key.tsx
+++ b/nr-app/app/onboarding/key.tsx
@@ -29,7 +29,7 @@ export default function OnboardingKeyScreen() {
   } = useKeyImport();
 
   const [currentTab, setCurrentTab] = useState<"existing" | "generate">(
-    "existing",
+    "generate",
   );
 
   const [existingKeyInput, setExistingKeyInput] = useState<string>("");
@@ -125,13 +125,13 @@ export default function OnboardingKeyScreen() {
         <KeyIcon size={128} color="#fff" strokeWidth={0.5} />
 
         <Text variant="h1" className="my-0">
-          Import Your Trustroots Key
+          Set Up Your Key
         </Text>
       </View>
 
       <Text className="text-center leading-relaxed">
-        Use this path if you have already added your Nostr public key to
-        Trustroots. Import the matching nsec or mnemonic on this device.
+        Generate a new Nostr key, or import one you already have. The next step
+        shows you how to add it to your Trustroots profile.
       </Text>
 
       <View className="flex w-full flex-col gap-6">

--- a/nr-app/app/onboarding/link.tsx
+++ b/nr-app/app/onboarding/link.tsx
@@ -218,13 +218,10 @@ export default function OnboardingLinkScreen() {
   };
 
   const goNext = () => {
-    if (keyWasImported) {
-      trackEvent("onboarding_completed", { method: "imported_key" });
-      router.replace(ROUTES.HOME);
-    } else {
-      trackEvent("onboarding_backup_started", { source: "legacy_key" });
-      router.push("/onboarding/backup-confirm");
-    }
+    trackEvent("onboarding_completed", {
+      method: keyWasImported ? "imported_key" : "generated_key",
+    });
+    router.replace(ROUTES.HOME);
   };
 
   return (

--- a/nr-app/app/onboarding/trustroots.tsx
+++ b/nr-app/app/onboarding/trustroots.tsx
@@ -288,13 +288,13 @@ export default function OnboardingTrustrootsScreen() {
       <View className="flex items-center gap-6">
         <MailCheckIcon size={128} color="#fff" strokeWidth={0.5} />
         <Text variant="h1" className="my-0">
-          Verify your Trustroots email
+          Connect your Trustroots account
         </Text>
       </View>
 
       <Text variant="p" className="mt-0">
-        Enter your Trustroots username. We’ll email the address on that account
-        with a six-digit code and an app link.
+        Enter your Trustroots username — not your email address. We’ll send a
+        six-digit code and an app link to the email address on that account.
       </Text>
 
       <View className="bg-card rounded-xl p-4 w-full gap-3">
@@ -378,7 +378,7 @@ export default function OnboardingTrustrootsScreen() {
                 title={
                   screenState === "requesting"
                     ? "Sending..."
-                    : "Verify Trustroots email"
+                    : "Send verification email"
                 }
                 disabled={isBusy}
                 onPress={handleRequestCode}
@@ -409,9 +409,13 @@ export default function OnboardingTrustrootsScreen() {
           textClassName="text-white"
           onPress={goLegacyKeyFlow}
           size="lg"
-          title="I’ve already set my key on Trustroots"
+          title="Set up my key manually"
           disabled={isBusy}
         />
+        <Text className="text-xs text-center">
+          Generate a new key or import one you already have, then add it to your
+          Trustroots profile yourself.
+        </Text>
       </View>
 
       <View className="flex flex-row gap-2">

--- a/nr-app/app/onboarding/trustroots.tsx
+++ b/nr-app/app/onboarding/trustroots.tsx
@@ -119,7 +119,7 @@ export default function OnboardingTrustrootsScreen() {
           method: "bridge",
           outcome: "success",
         });
-        router.replace("/onboarding/backup-confirm?from=bridge");
+        router.replace("/onboarding/backup-confirm");
       } catch (error) {
         trackEvent("onboarding_profile_publish", {
           method: "bridge",

--- a/nr-app/app/verify.tsx
+++ b/nr-app/app/verify.tsx
@@ -39,7 +39,7 @@ export default function VerifyRoute() {
             pendingTrustrootsProfileUsername,
             dispatch,
           );
-          router.replace("/onboarding/backup-confirm?from=bridge");
+          router.replace("/onboarding/backup-confirm");
         } catch (error) {
           console.error("Failed to retry Trustroots profile publish", error);
           router.replace("/onboarding/trustroots");
@@ -63,7 +63,7 @@ export default function VerifyRoute() {
           pendingTrustrootsUsername,
           dispatch,
         );
-        router.replace("/onboarding/backup-confirm?from=bridge");
+        router.replace("/onboarding/backup-confirm");
       } catch (error) {
         console.error("Failed to authenticate Trustroots deep link", error);
         router.replace("/onboarding/trustroots?error=auth");

--- a/nr-app/src/components/BackupChallenge.tsx
+++ b/nr-app/src/components/BackupChallenge.tsx
@@ -1,0 +1,139 @@
+import React, { useMemo, useState } from "react";
+import { TextInput, View } from "react-native";
+
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import {
+  BackupChallenge as Challenge,
+  checkBackupChallenge,
+  createBackupChallenge,
+} from "@/utils/backupChallenge.utils";
+
+interface BackupChallengeProps {
+  secret: string;
+  confirmed: boolean;
+  onConfirmed: () => void;
+  onFailed?: () => void;
+  testIDPrefix: string;
+}
+
+function formatPositions(positions: number[]): string {
+  const labels = positions.map((position) => `${position}`);
+  const last = labels.pop();
+  return labels.length ? `${labels.join(", ")} and ${last}` : `${last}`;
+}
+
+export function BackupChallenge({
+  secret,
+  confirmed,
+  onConfirmed,
+  onFailed,
+  testIDPrefix,
+}: BackupChallengeProps) {
+  // Mount-time challenge; callers remount with key={secret} to reroll it.
+  const [challenge] = useState<Challenge>(() => createBackupChallenge(secret));
+  const [answers, setAnswers] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const fieldCount =
+    challenge.type === "mnemonic" ? challenge.positions.length : 1;
+
+  const prompt = useMemo(
+    () =>
+      challenge.type === "mnemonic"
+        ? `Enter word ${formatPositions(challenge.positions)} from the backup you just saved.`
+        : "Enter your secret from the backup you just saved.",
+    [challenge],
+  );
+
+  const setAnswer = (index: number, value: string) => {
+    setAnswers((current) => {
+      const next = [...current];
+      next[index] = value;
+      return next;
+    });
+    setError(null);
+  };
+
+  const hasEveryAnswer = Array.from({ length: fieldCount }).every((_, index) =>
+    (answers[index] ?? "").trim(),
+  );
+
+  const handleConfirm = () => {
+    const filled = Array.from(
+      { length: fieldCount },
+      (_, index) => answers[index] ?? "",
+    );
+
+    if (checkBackupChallenge(challenge, secret, filled)) {
+      setError(null);
+      onConfirmed();
+      return;
+    }
+
+    setError(
+      challenge.type === "mnemonic"
+        ? "That does not match your backup. Check the numbered words and try again."
+        : "That does not match your backup. Check it and try again.",
+    );
+    onFailed?.();
+  };
+
+  return (
+    <View className="w-full gap-3">
+      <Text className="text-sm text-muted-foreground text-left">{prompt}</Text>
+
+      {challenge.type === "mnemonic" ? (
+        <View className="flex flex-row gap-2">
+          {challenge.positions.map((position, index) => (
+            <View key={position} className="flex-1 gap-1">
+              <Text className="text-xs text-muted-foreground text-left">
+                Word {position}
+              </Text>
+              <TextInput
+                testID={`${testIDPrefix}-word-${position}`}
+                value={answers[index] ?? ""}
+                onChangeText={(value) => setAnswer(index, value)}
+                editable={!confirmed}
+                autoCapitalize="none"
+                autoCorrect={false}
+                placeholderTextColor="#6b7280"
+                className="w-full bg-muted text-foreground rounded-md p-3 text-sm text-left"
+              />
+            </View>
+          ))}
+        </View>
+      ) : (
+        <TextInput
+          testID={`${testIDPrefix}-secret`}
+          value={answers[0] ?? ""}
+          onChangeText={(value) => setAnswer(0, value)}
+          editable={!confirmed}
+          autoCapitalize="none"
+          autoCorrect={false}
+          multiline
+          placeholder="nsec1..."
+          placeholderTextColor="#6b7280"
+          className="w-full bg-muted text-foreground rounded-md p-3 text-sm min-h-[72px]"
+        />
+      )}
+
+      {error && <Text className="text-xs text-red-500 text-left">{error}</Text>}
+
+      {confirmed && (
+        <Text className="text-xs text-green-400 text-left">
+          Backup confirmed.
+        </Text>
+      )}
+
+      <Button
+        testID={`${testIDPrefix}-confirm`}
+        variant="secondary"
+        size="lg"
+        title={confirmed ? "Backup confirmed" : "Confirm backup"}
+        disabled={confirmed || !hasEveryAnswer}
+        onPress={handleConfirm}
+      />
+    </View>
+  );
+}

--- a/nr-app/src/test/routes/onboarding/backup-confirm.test.tsx
+++ b/nr-app/src/test/routes/onboarding/backup-confirm.test.tsx
@@ -9,9 +9,17 @@ import OnboardingBackupConfirmScreen from "../../../../app/onboarding/backup-con
 const mnemonic =
   "romance slim fame pipe puzzle priority actress must impulse tape super bike";
 
+const words = mnemonic.split(" ");
+
 describe("OnboardingBackupConfirmScreen", () => {
   beforeEach(() => {
     resetSecureStoreMock();
+    // Makes the challenge ask for words 1, 2 and 3.
+    jest.spyOn(Math, "random").mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("shows setup error when no key is present", async () => {
@@ -26,10 +34,10 @@ describe("OnboardingBackupConfirmScreen", () => {
     });
   });
 
-  it("confirms a generated mnemonic backup", async () => {
+  async function revealSecret() {
     await setPrivateKeyInSecureStorage({ mnemonic });
 
-    const { router } = renderWithProviders(<OnboardingBackupConfirmScreen />, {
+    const rendered = renderWithProviders(<OnboardingBackupConfirmScreen />, {
       preloadedState: {
         settings: {
           ...settingsSlice.getInitialState(),
@@ -39,23 +47,55 @@ describe("OnboardingBackupConfirmScreen", () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Save this secret before continuing"),
-      ).toBeTruthy();
+      expect(screen.getByTestId("onboarding-backup-secret")).toBeTruthy();
     });
 
-    fireEvent.changeText(
-      screen.getByPlaceholderText(
-        "Paste your nsec1... key or type your 12/24-word mnemonic",
+    fireEvent.press(screen.getByText("I have saved my secret"));
+
+    return rendered;
+  }
+
+  it("hides the secret once it is acknowledged", async () => {
+    await revealSecret();
+
+    expect(screen.queryByTestId("onboarding-backup-secret")).toBeNull();
+    expect(screen.getByTestId("onboarding-backup-word-1")).toBeTruthy();
+  });
+
+  it("rejects wrong words and keeps Finish disabled", async () => {
+    const { router } = await revealSecret();
+
+    words.slice(0, 3).forEach((_, index) => {
+      fireEvent.changeText(
+        screen.getByTestId(`onboarding-backup-word-${index + 1}`),
+        "wrong",
+      );
+    });
+    fireEvent.press(screen.getByText("Confirm backup"));
+
+    expect(
+      screen.getByText(
+        "That does not match your backup. Check the numbered words and try again.",
       ),
-      mnemonic,
-    );
+    ).toBeTruthy();
+
+    fireEvent.press(screen.getByText("Finish"));
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it("confirms a generated mnemonic backup by its numbered words", async () => {
+    const { router } = await revealSecret();
+
+    words.slice(0, 3).forEach((word, index) => {
+      fireEvent.changeText(
+        screen.getByTestId(`onboarding-backup-word-${index + 1}`),
+        word,
+      );
+    });
     fireEvent.press(screen.getByText("Confirm backup"));
 
     await waitFor(() => {
-      expect(
-        screen.getByText("You’re all set — backup confirmed."),
-      ).toBeTruthy();
+      expect(screen.getByText("Backup confirmed.")).toBeTruthy();
     });
 
     fireEvent.press(screen.getByText("Finish"));

--- a/nr-app/src/test/routes/onboarding/key.test.tsx
+++ b/nr-app/src/test/routes/onboarding/key.test.tsx
@@ -26,6 +26,8 @@ describe("OnboardingKeyScreen", () => {
   it("imports an existing key before continuing to legacy link flow", async () => {
     const { router } = renderWithProviders(<OnboardingKeyScreen />);
 
+    fireEvent.press(screen.getByText("Import"));
+
     fireEvent.changeText(
       screen.getByPlaceholderText("Paste your nsec or mnemonic"),
       "test mnemonic",
@@ -35,6 +37,54 @@ describe("OnboardingKeyScreen", () => {
     await waitFor(() => {
       expect(mockImportKey).toHaveBeenCalledWith("test mnemonic");
       expect(screen.getByText("Saved")).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByText("Continue"));
+
+    await waitFor(() => {
+      expect(router.push).toHaveBeenCalledWith("/onboarding/link");
+    });
+  });
+
+  it("blocks Continue until the generated words survive the spot-check", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+
+    const { router } = renderWithProviders(<OnboardingKeyScreen />);
+
+    const generatedWords = screen
+      .getByTestId("onboarding-key-mnemonic-input")
+      .props.value.split(" ");
+
+    fireEvent.press(screen.getByText("I have saved these words safely"));
+
+    // The words are hidden while they are being checked.
+    expect(screen.queryByTestId("onboarding-key-mnemonic-input")).toBeNull();
+
+    fireEvent.changeText(
+      screen.getByTestId("onboarding-key-backup-word-1"),
+      "wrong",
+    );
+    fireEvent.changeText(
+      screen.getByTestId("onboarding-key-backup-word-2"),
+      generatedWords[1],
+    );
+    fireEvent.changeText(
+      screen.getByTestId("onboarding-key-backup-word-3"),
+      generatedWords[2],
+    );
+    fireEvent.press(screen.getByText("Confirm backup"));
+
+    fireEvent.press(screen.getByText("Continue"));
+    expect(router.push).not.toHaveBeenCalled();
+
+    fireEvent.changeText(
+      screen.getByTestId("onboarding-key-backup-word-1"),
+      generatedWords[0],
+    );
+    fireEvent.press(screen.getByText("Confirm backup"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Backup confirmed.")).toBeTruthy();
     });
 
     fireEvent.press(screen.getByText("Continue"));

--- a/nr-app/src/test/routes/onboarding/trustroots.test.tsx
+++ b/nr-app/src/test/routes/onboarding/trustroots.test.tsx
@@ -30,7 +30,7 @@ describe("OnboardingTrustrootsScreen", () => {
   it("validates username before requesting a code", () => {
     renderWithProviders(<OnboardingTrustrootsScreen />);
 
-    fireEvent.press(screen.getByText("Verify Trustroots email"));
+    fireEvent.press(screen.getByText("Send verification email"));
 
     expect(screen.getByText("Enter your Trustroots username.")).toBeTruthy();
     expect(bridge.requestVerificationToken).not.toHaveBeenCalled();
@@ -40,7 +40,7 @@ describe("OnboardingTrustrootsScreen", () => {
     renderWithProviders(<OnboardingTrustrootsScreen />);
 
     fireEvent.changeText(screen.getByPlaceholderText("your-username"), "Alice");
-    fireEvent.press(screen.getByText("Verify Trustroots email"));
+    fireEvent.press(screen.getByText("Send verification email"));
 
     await waitFor(() => {
       expect(bridge.requestVerificationToken).toHaveBeenCalledWith("alice");
@@ -67,9 +67,7 @@ describe("OnboardingTrustrootsScreen", () => {
         npub: "npub1test",
         username: "alice",
       });
-      expect(router.replace).toHaveBeenCalledWith(
-        "/onboarding/backup-confirm?from=bridge",
-      );
+      expect(router.replace).toHaveBeenCalledWith("/onboarding/backup-confirm");
     });
   });
 });

--- a/nr-app/src/test/routes/verify.test.tsx
+++ b/nr-app/src/test/routes/verify.test.tsx
@@ -60,9 +60,7 @@ describe("VerifyRoute", () => {
         token: "token-1",
         username: "alice",
       });
-      expect(router.replace).toHaveBeenCalledWith(
-        "/onboarding/backup-confirm?from=bridge",
-      );
+      expect(router.replace).toHaveBeenCalledWith("/onboarding/backup-confirm");
     });
   });
 });

--- a/nr-app/src/utils/backupChallenge.utils.test.ts
+++ b/nr-app/src/utils/backupChallenge.utils.test.ts
@@ -40,13 +40,15 @@ describe("createBackupChallenge", () => {
   });
 
   it("uses the injected random source", () => {
-    const values = [0, 0, 0.5, 0.99];
-    const challenge = createBackupChallenge(
-      MNEMONIC,
-      () => values.shift() ?? 0,
-    );
+    expect(createBackupChallenge(MNEMONIC, () => 0)).toEqual({
+      type: "mnemonic",
+      positions: [1, 2, 3],
+    });
 
-    expect(challenge).toEqual({ type: "mnemonic", positions: [1, 7, 12] });
+    expect(createBackupChallenge(MNEMONIC, () => 0.999)).toEqual({
+      type: "mnemonic",
+      positions: [10, 11, 12],
+    });
   });
 
   it("falls back to a full-secret challenge for an nsec", () => {

--- a/nr-app/src/utils/backupChallenge.utils.test.ts
+++ b/nr-app/src/utils/backupChallenge.utils.test.ts
@@ -1,0 +1,112 @@
+import {
+  checkBackupChallenge,
+  createBackupChallenge,
+  isMnemonicSecret,
+} from "./backupChallenge.utils";
+
+const MNEMONIC =
+  "abandon ability able about above absent absorb abstract absurd abuse access accident";
+const NSEC = "nsec1exampleexampleexampleexampleexampleexampleexampleexample";
+
+describe("isMnemonicSecret", () => {
+  it("recognises supported mnemonic lengths", () => {
+    expect(isMnemonicSecret(MNEMONIC)).toBe(true);
+    expect(isMnemonicSecret(`  ${MNEMONIC}  `)).toBe(true);
+  });
+
+  it("rejects an nsec and other word counts", () => {
+    expect(isMnemonicSecret(NSEC)).toBe(false);
+    expect(isMnemonicSecret("one two three")).toBe(false);
+    expect(isMnemonicSecret("")).toBe(false);
+  });
+});
+
+describe("createBackupChallenge", () => {
+  it("asks for three distinct, ascending, in-range positions", () => {
+    const challenge = createBackupChallenge(MNEMONIC);
+
+    expect(challenge.type).toBe("mnemonic");
+    if (challenge.type !== "mnemonic") throw new Error("unreachable");
+
+    expect(challenge.positions).toHaveLength(3);
+    expect(new Set(challenge.positions).size).toBe(3);
+    expect([...challenge.positions].sort((a, b) => a - b)).toEqual(
+      challenge.positions,
+    );
+    challenge.positions.forEach((position) => {
+      expect(position).toBeGreaterThanOrEqual(1);
+      expect(position).toBeLessThanOrEqual(12);
+    });
+  });
+
+  it("uses the injected random source", () => {
+    const values = [0, 0, 0.5, 0.99];
+    const challenge = createBackupChallenge(
+      MNEMONIC,
+      () => values.shift() ?? 0,
+    );
+
+    expect(challenge).toEqual({ type: "mnemonic", positions: [1, 7, 12] });
+  });
+
+  it("falls back to a full-secret challenge for an nsec", () => {
+    expect(createBackupChallenge(NSEC)).toEqual({ type: "secret" });
+  });
+});
+
+describe("checkBackupChallenge", () => {
+  const challenge = { type: "mnemonic" as const, positions: [1, 7, 12] };
+
+  it("accepts the right words", () => {
+    expect(
+      checkBackupChallenge(challenge, MNEMONIC, [
+        "abandon",
+        "absorb",
+        "accident",
+      ]),
+    ).toBe(true);
+  });
+
+  it("ignores case and surrounding whitespace", () => {
+    expect(
+      checkBackupChallenge(challenge, MNEMONIC, [
+        " Abandon ",
+        "ABSORB",
+        "accident",
+      ]),
+    ).toBe(true);
+  });
+
+  it("rejects a wrong word", () => {
+    expect(
+      checkBackupChallenge(challenge, MNEMONIC, ["abandon", "absorb", "abuse"]),
+    ).toBe(false);
+  });
+
+  it("rejects blank or missing answers", () => {
+    expect(
+      checkBackupChallenge(challenge, MNEMONIC, ["abandon", "absorb"]),
+    ).toBe(false);
+    expect(
+      checkBackupChallenge(challenge, MNEMONIC, ["abandon", "absorb", "  "]),
+    ).toBe(false);
+  });
+
+  it("rejects pasting the whole mnemonic into one field", () => {
+    expect(
+      checkBackupChallenge(challenge, MNEMONIC, [MNEMONIC, MNEMONIC, MNEMONIC]),
+    ).toBe(false);
+  });
+
+  it("compares the full secret for the nsec fallback", () => {
+    const secretChallenge = { type: "secret" as const };
+    expect(checkBackupChallenge(secretChallenge, NSEC, [NSEC])).toBe(true);
+    expect(checkBackupChallenge(secretChallenge, NSEC, [` ${NSEC} `])).toBe(
+      true,
+    );
+    expect(checkBackupChallenge(secretChallenge, NSEC, ["nsec1nope"])).toBe(
+      false,
+    );
+    expect(checkBackupChallenge(secretChallenge, "", [""])).toBe(false);
+  });
+});

--- a/nr-app/src/utils/backupChallenge.utils.ts
+++ b/nr-app/src/utils/backupChallenge.utils.ts
@@ -1,0 +1,60 @@
+export type BackupChallenge =
+  | { type: "mnemonic"; positions: number[] }
+  | { type: "secret" };
+
+const MNEMONIC_LENGTHS = [12, 15, 18, 21, 24];
+const MNEMONIC_CHALLENGE_SIZE = 3;
+
+function splitWords(secret: string): string[] {
+  return secret.trim().toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+export function isMnemonicSecret(secret: string): boolean {
+  return MNEMONIC_LENGTHS.includes(splitWords(secret).length);
+}
+
+/**
+ * Positions are 1-based and returned in ascending order so the prompt reads
+ * naturally ("words 4, 9 and 12").
+ */
+export function createBackupChallenge(
+  secret: string,
+  random: () => number = Math.random,
+): BackupChallenge {
+  if (!isMnemonicSecret(secret)) {
+    return { type: "secret" };
+  }
+
+  const wordCount = splitWords(secret).length;
+  const positions = new Set<number>();
+
+  while (positions.size < MNEMONIC_CHALLENGE_SIZE) {
+    positions.add(Math.floor(random() * wordCount) + 1);
+  }
+
+  return {
+    type: "mnemonic",
+    positions: [...positions].sort((a, b) => a - b),
+  };
+}
+
+export function checkBackupChallenge(
+  challenge: BackupChallenge,
+  secret: string,
+  answers: string[],
+): boolean {
+  if (challenge.type === "secret") {
+    const expected = secret.trim().toLowerCase();
+    const given = (answers[0] ?? "").trim().toLowerCase();
+    return expected.length > 0 && given === expected;
+  }
+
+  const words = splitWords(secret);
+  if (answers.length !== challenge.positions.length) return false;
+
+  return challenge.positions.every((position, index) => {
+    const expected = words[position - 1];
+    const given = (answers[index] ?? "").trim().toLowerCase();
+    return !!expected && given === expected;
+  });
+}

--- a/nr-app/src/utils/backupChallenge.utils.ts
+++ b/nr-app/src/utils/backupChallenge.utils.ts
@@ -26,15 +26,21 @@ export function createBackupChallenge(
   }
 
   const wordCount = splitWords(secret).length;
-  const positions = new Set<number>();
+  // Draw without replacement so a degenerate `random` cannot loop forever.
+  const remaining = Array.from({ length: wordCount }, (_, index) => index + 1);
+  const positions: number[] = [];
 
-  while (positions.size < MNEMONIC_CHALLENGE_SIZE) {
-    positions.add(Math.floor(random() * wordCount) + 1);
+  while (positions.length < MNEMONIC_CHALLENGE_SIZE) {
+    const index = Math.min(
+      remaining.length - 1,
+      Math.max(0, Math.floor(random() * remaining.length)),
+    );
+    positions.push(remaining.splice(index, 1)[0]);
   }
 
   return {
     type: "mnemonic",
-    positions: [...positions].sort((a, b) => a - b),
+    positions: positions.sort((a, b) => a - b),
   };
 }
 


### PR DESCRIPTION
Onboarding: three confusing labels, and a backup step that both duplicated an earlier one and did not verify anything.

### Trustroots step asked for an email but wanted a username
- Title: "Verify your Trustroots email" → **"Connect your Trustroots account"**
- Copy now says explicitly: enter your Trustroots *username*, not your email address; the code goes to the email on that account.
- Primary button: "Verify Trustroots email" → **"Send verification email"**

### "I've already set my key on Trustroots" is the general manual path
- Relabelled **"Set up my key manually"**, with a hint that you can generate a new key *or* import one and add it to your profile yourself.
- `/onboarding/key` now defaults to the **Generate** tab (still preselects Import when a key already exists on device). Title → "Set Up Your Key".

### Reveal the key once, confirm it in place
Before: the manual path showed the mnemonic on the key screen with a copy button and an honour-system "I have saved these words safely", then two screens later `backup-confirm` showed the same secret *again* and asked you to retype all of it — annoying, and satisfiable by copy-paste.

Now each path reveals the secret exactly once and challenges it on the same screen:
- **Manual path** — generate tab: words shown (copy/regenerate available) → "I have saved these words safely" → words hide and the challenge appears inline. "Show my words again" goes back. Continue stays disabled until the challenge passes. `link.tsx` then finishes straight to home, so `backup-confirm` drops out of this path entirely (it already did for imports).
- **Bridge/email path** — the key is generated silently, so `backup-confirm` remains its single reveal-then-challenge screen.

The challenge asks for **three words by position** ("word 4, 9 and 12") instead of the full phrase — seconds instead of a minute, can't be satisfied by pasting the whole string, and still proves the backup is at hand. When the secret is an nsec rather than a mnemonic there are no word positions, so it falls back to full re-entry.

New `BackupChallenge` component over pure `createBackupChallenge` / `checkBackupChallenge` utils, unit-tested (11 tests, incl. the paste-the-whole-mnemonic case).

### Notes
- `nr-app` jest suite green (141 tests), `tsc --noEmit` and prettier clean on the touched files. No new eslint errors (two pre-existing `set-state-in-effect` errors in `trustroots.tsx` are untouched).
- Maestro: `onboarding-generate.yaml` now copies the mnemonic, then a new `subflows/answer-backup-challenge.yaml` fills whichever three positions are asked. **Not executed** — no simulator run in this session, so treat the flow changes as unverified.
- `?from=bridge` is gone; `verify.tsx` and `trustroots.tsx` route to plain `/onboarding/backup-confirm`.