### PR TITLE
Harden Nostr key generation and storage

### DIFF
--- a/docs/key-generation-audit.md
+++ b/docs/key-generation-audit.md
@@ -1,0 +1,97 @@
+# Nostr key generation and recovery audit
+
+Audited against `origin/main` through `6a7b486b` on 2026-08-04. The review covered
+production, development, test, and ephemeral Nostr secret generation; mnemonic
+derivation; import validation; persistence; and accidental secret disclosure.
+
+## Status legend
+
+- 🟢 Cryptographically strong and appropriate for the stated lifetime
+- 🟡 Strong randomness, with a separate storage or operational concern
+- 🟠 Material weakness that is not an immediate key compromise
+- 🔴 Incorrect, unsafe, or incompatible behavior that needs a decision or fix
+- ⚪ Development/test-only material that is not a production identity
+
+## Priority summary
+
+| Priority | Status | Finding | Resolution |
+| --- | --- | --- | --- |
+| P1 | 🔴 → 🟢 | Mnemonics derived different identities across clients | Web and both Swift parsers use NIP-06 on `main`, matching `nr-app` and the extension. |
+| P1 | 🔴 → 🟢 | Mobile debugging could expose key generation to a `Math.random()` fallback | The shim is removed; an early Expo Crypto bootstrap requests 128 bits and fails closed. |
+| P1 | 🔴 → 🟢 | The validation server generated a new signing identity and logged its `nsec` when configuration was absent | Production now requires `PRIVATE_KEY_NSEC`; only development may use an ephemeral key, and only its public key is logged. |
+| P2 | 🟠 → 🟢 | Mobile import accepted arbitrary text or a public-only `npub` as a recovery phrase | Imports now validate the BIP-39 checksum and reject public-only keys. |
+| P2 | 🟠 → 🟢 | Partial mobile storage writes could split the displayed and signing identities | Replacement writes roll back and the stored signing key is canonical. |
+| P2 | 🟠 → 🟢 | Swift import/generation accepted zero or out-of-range secp256k1 values | Both native implementations validate `1...n-1` and use rejection sampling on `main`. |
+| P2 | 🟠 | Web and extension secrets live in browser-readable storage | Prefer NIP-07, reduce same-origin script exposure, and treat origin permissions as part of the key boundary. |
+| P3 | 🟡 | Browser key replacement and remembered origin permissions are separate writes | Make replacement a recoverable transaction in a follow-up. |
+
+## Generation inventory
+
+| Status | Component and location                                                                            | Key lifetime               | Random input and effective entropy                                                                                | Notes                                                                                                                                                                                                     |
+| ------ | ------------------------------------------------------------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 🟢     | `nr-app` onboarding (`src/components/KeyInput.tsx`, `src/services/onboardingIdentity.service.ts`) | Persistent recovery phrase | `nip06.generateSeedWords()` uses 128 random bits for 12 BIP-39 words                                              | This change installs Expo Crypto's native CSPRNG before key modules load, avoiding the React Native shim's `Math.random()` remote-debug fallback. Tests assert 16-byte requests and fail-closed behavior. |
+| 🟡     | Nostroots Web (`vibe/web/web/index.js`, `generateKeyPair`)                                        | Persistent local key       | `nostr-tools.generateSecretKey()` maps CSPRNG bytes into a valid secp256k1 scalar; approximately 256-bit security | The private key is kept in same-origin `localStorage`, so any successful same-origin script injection can read it. Prefer NIP-07 for valuable identities.                                                 |
+| 🟢     | Nostroots Web gift wrapping (`vibe/web/web/index.js`)                                             | One message                | `nostr-tools.generateSecretKey()`; approximately 256-bit security                                                 | Correct ephemeral use for NIP-59-style wrapping.                                                                                                                                                          |
+| 🟡     | Browser extension (`vibe/browser/extension/src/shared/keys.ts`)                                   | Persistent signer key      | NIP-06 mnemonic generation uses 128 random bits; the raw helper uses `nostr-tools`                                | The secret is stored in `chrome.storage.local`; origin permissions should be treated as part of the key's security boundary.                                                                              |
+| 🟢     | Native Nostroots Browser (`vibe/browser/ios/SharedCore/Crypto/NIP19.swift`)                       | Persistent Keychain key    | `SecRandomCopyBytes`, 256 random bits, with rejection outside `1...n-1`                                           | The implementation on `main` validates the full secp256k1 scalar range during generation, import, storage, and `nsec` encoding.                                                                            |
+| 🟢     | Nostroots native iOS companion (`vibe/web/ios-app/SharedCore/Crypto/NIP19.swift`)                 | Persistent Keychain key    | `SecRandomCopyBytes`, 256 random bits, with rejection outside `1...n-1`                                           | The implementation on `main` validates the full scalar range during generation and import.                                                                                                                |
+| 🟡     | Validation server (`nr-server/main.ts`)                                                           | Long-lived server identity | `nostr-tools.generateSecretKey()` when explicitly in development                                                  | This PR requires `PRIVATE_KEY_NSEC` outside development and never logs a generated `nsec`. The old production fallback silently changed identity on every restart and disclosed the secret in logs.       |
+| 🟢     | Monitor probes (`nr-monitor/src/ping.ts`)                                                         | One process/probe          | `nostr-tools.generateSecretKey()`                                                                                 | Appropriate ephemeral authentication identity.                                                                                                                                                            |
+| ⚪     | NIP-46 development client (`development-utils/nip-46-client`)                                     | Development session        | `nostr-tools.generateSecretKey()` and `crypto.randomUUID()`                                                       | Development-only tooling; no production identity depends on it.                                                                                                                                           |
+| ⚪     | Push spam helper and Go tests (`nr-push/spam.ts`, `vibe/nip42relay`)                              | Development/test           | Fixed or library-generated test values                                                                            | Acceptable only while these paths remain clearly non-production.                                                                                                                                          |
+
+## Entropy conclusion
+
+The intended generators provide enough randomness. Twelve-word NIP-06/BIP-39
+phrases contain 128 bits of entropy plus a checksum, already beyond practical
+brute-force reach. Direct secret generators use OS-backed cryptographic random
+sources and produce valid 256-bit secp256k1 scalars. Adding more random bytes
+would not materially improve security.
+
+The mobile app was the exception under Chrome remote debugging: its installed
+`react-native-get-random-values` shim deliberately fell back to `Math.random()`.
+The app now replaces that method with Expo Crypto's native implementation and
+therefore fails closed if secure randomness is unavailable.
+
+## High-priority compatibility finding and resolution
+
+Before the Vibe update on `main`, the same 12-word recovery phrase did **not**
+restore the same Nostr identity in all clients:
+
+| Client                                      | Previous derivation                       |
+| ------------------------------------------- | ----------------------------------------- |
+| `nr-app` and the browser extension          | NIP-06 / BIP-32 path `m/44'/1237'/0'/0/0` |
+| Nostroots Web and both Swift native parsers | First 32 bytes of the BIP-39 seed         |
+
+For the standard `abandon ... about` vector these paths produced different
+private keys. Nostroots Web and both Swift parsers now use the NIP-06 path, with
+the standard-derived secret locked by regression tests. Existing installations
+continue using their persisted raw key; a phrase previously imported through a
+legacy client will resolve to the NIP-06 identity if it is imported again. This
+deliberate recovery compatibility break was accepted because legacy usage is
+known to be low.
+
+## Other findings and recommendations
+
+1. `nr-app` previously treated arbitrary text and `npub` values as recovery
+   phrases. Import now validates BIP-39 checksums, rejects public-only keys, and
+   accepts case-normalized `nsec` input.
+2. `nr-app` could navigate away before SecureStore finished writing. It now
+   waits for success. Replacement writes also roll back on failure, and the
+   actual signing key is canonical if a stale mnemonic remains.
+3. Nostroots Web loads several third-party modules while allowing a raw secret
+   in `localStorage`. Self-host and pin all executable dependencies, deploy a
+   strict Content Security Policy, and make NIP-07 the recommended default.
+4. Browser-extension and native-browser key replacement should update key
+   storage and remembered origin permissions as one recoverable operation.
+5. Hex validators shared across JavaScript clients generally check length and
+   characters only. Import boundaries should consistently reject zero and
+   values at or above the secp256k1 group order before persistence.
+
+## Review method
+
+The inventory was built by tracing calls to `generateSecretKey`,
+`generateSeedWords`, `SecRandomCopyBytes`, `randomBytes`, `randomUUID`, NIP-19
+encoders, mnemonic parsers, key persistence APIs, and committed fixed-key
+fixtures. Generator implementations were then traced into the installed
+`nostr-tools`, Noble, Scure BIP-39, Expo Crypto, and React Native shim sources.

--- a/docs/key-generation-audit.md
+++ b/docs/key-generation-audit.md
@@ -1,6 +1,6 @@
 # Nostr key generation and recovery audit
 
-Audited against `origin/main` through `6a7b486b` on 2026-08-04. The review covered
+Audited against `origin/main` through `bca7def4` on 2026-08-04. The review covered
 production, development, test, and ephemeral Nostr secret generation; mnemonic
 derivation; import validation; persistence; and accidental secret disclosure.
 
@@ -52,6 +52,11 @@ The mobile app was the exception under Chrome remote debugging: its installed
 `react-native-get-random-values` shim deliberately fell back to `Math.random()`.
 The app now replaces that method with Expo Crypto's native implementation and
 therefore fails closed if secure randomness is unavailable.
+
+Focused coverage is enforced at 100% statements, branches, functions, and
+lines for the mobile CSPRNG bootstrap, key-input parser, and secure keystore.
+The validation server's private-key resolver also reports 100% branch,
+function, and line coverage.
 
 ## High-priority compatibility finding and resolution
 

--- a/nr-app/app/(main)/(views)/connect.tsx
+++ b/nr-app/app/(main)/(views)/connect.tsx
@@ -5,7 +5,6 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 import { Stack } from "expo-router";
 import { useState } from "react";
 import { ScrollView, TextInput } from "react-native";
-import "react-native-get-random-values";
 
 export default function TabFourScreen() {
   const [connectURI, setConnectURI] = useState("");

--- a/nr-app/app/onboarding/key.tsx
+++ b/nr-app/app/onboarding/key.tsx
@@ -77,16 +77,17 @@ export default function OnboardingKeyScreen() {
   const saveGeneratedMnemonic = useCallback(async () => {
     if (!mnemonic || !mnemonicConfirmed) {
       setMnemonicError("Please save and confirm your words before continuing.");
-      return;
+      return false;
     }
 
     try {
-      dispatch(setPrivateKeyPromiseAction.request({ mnemonic }));
+      await dispatch(setPrivateKeyPromiseAction.request({ mnemonic }));
       dispatch(settingsActions.setKeyWasImported(false));
       trackEvent("onboarding_key_saved", {
         method: "generated",
         outcome: "success",
       });
+      return true;
     } catch (error) {
       trackEvent("onboarding_key_saved", {
         method: "generated",
@@ -94,6 +95,7 @@ export default function OnboardingKeyScreen() {
       });
       console.error("Failed to save mnemonic", error);
       setMnemonicError("We could not set up this key. Please try again.");
+      return false;
     }
   }, [dispatch, mnemonic, mnemonicConfirmed]);
 
@@ -107,7 +109,8 @@ export default function OnboardingKeyScreen() {
 
   const goNext = useCallback(async () => {
     if (currentTab === "generate") {
-      await saveGeneratedMnemonic();
+      const saved = await saveGeneratedMnemonic();
+      if (!saved) return;
     }
 
     trackEvent("onboarding_key_completed", { method: currentTab });

--- a/nr-app/jest.key-coverage.config.js
+++ b/nr-app/jest.key-coverage.config.js
@@ -1,0 +1,24 @@
+const baseConfig = require("./jest.config");
+
+module.exports = {
+  ...baseConfig,
+  collectCoverageFrom: [
+    "src/secureRandom.ts",
+    "src/secureRandom.bootstrap.ts",
+    "src/hooks/useKeyImport.ts",
+    "src/nostr/keystore.nostr.ts",
+  ],
+  testMatch: [
+    "<rootDir>/src/secureRandom.test.ts",
+    "<rootDir>/src/hooks/useKeyImport.test.ts",
+    "<rootDir>/src/nostr/keystore.nostr.test.ts",
+  ],
+  coverageThreshold: {
+    global: {
+      statements: 100,
+      branches: 100,
+      functions: 100,
+      lines: 100,
+    },
+  },
+};

--- a/nr-app/package.json
+++ b/nr-app/package.json
@@ -12,6 +12,7 @@
     "test": "jest --watchman=false",
     "test:ci": "jest --ci --coverage --runInBand --watchman=false --json --outputFile=coverage/test-results.json",
     "test:coverage": "jest --coverage --watchman=false",
+    "test:key-coverage": "jest --config jest.key-coverage.config.js --coverage --runInBand --watchman=false",
     "test:watch": "jest --watch --watchman=false",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/nr-app/package.json
+++ b/nr-app/package.json
@@ -73,7 +73,6 @@
     "react-dom": "19.2.3",
     "react-native": "0.85.3",
     "react-native-gesture-handler": "~2.31.2",
-    "react-native-get-random-values": "^1.11.0",
     "react-native-keyboard-controller": "^1.21.6",
     "react-native-logs": "^5.6.0",
     "react-native-reanimated": "~4.3.1",

--- a/nr-app/src/hooks/useKeyImport.test.ts
+++ b/nr-app/src/hooks/useKeyImport.test.ts
@@ -13,23 +13,26 @@ describe("useKeyImport", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (useAppDispatch as jest.Mock).mockReturnValue(dispatch);
+    (useAppDispatch as unknown as jest.Mock).mockReturnValue(dispatch);
     dispatch.mockResolvedValue(undefined);
     jest.spyOn(console, "error").mockImplementation(() => undefined);
   });
 
-  it("imports a mnemonic after trimming whitespace", async () => {
+  it("imports a validated mnemonic after normalizing case and whitespace", async () => {
     const { result } = renderHook(() => useKeyImport());
+    const mnemonic =
+      "ABANDON abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
     await act(async () => {
       await expect(
-        result.current.importKey("  one two three four  "),
+        result.current.importKey(`  ${mnemonic}  `),
       ).resolves.toEqual({ success: true, type: "mnemonic" });
     });
 
     expect(dispatch).toHaveBeenCalledWith(
       setPrivateKeyPromiseAction.request({
-        mnemonic: "one two three four",
+        mnemonic:
+          "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
       }),
     );
     expect(result.current.isImporting).toBe(false);
@@ -72,6 +75,20 @@ describe("useKeyImport", () => {
     expect(result.current.error).toBe(
       "That key format does not look right. Check and try again.",
     );
+
+    await act(async () => {
+      await result.current.importKey("one two three four");
+    });
+    expect(result.current.error).toBe(
+      "That recovery phrase is not valid. Check the words and their order.",
+    );
+
+    await act(async () => {
+      await result.current.importKey(
+        "npub10xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqpkge6d",
+      );
+    });
+    expect(result.current.error).toMatch(/public npub/i);
   });
 
   it("reports storage failures and allows clearing the error", async () => {
@@ -79,7 +96,11 @@ describe("useKeyImport", () => {
     const { result } = renderHook(() => useKeyImport());
 
     await act(async () => {
-      await expect(result.current.importKey("word list")).resolves.toEqual({
+      await expect(
+        result.current.importKey(
+          "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+        ),
+      ).resolves.toEqual({
         success: false,
         type: null,
       });

--- a/nr-app/src/hooks/useKeyImport.ts
+++ b/nr-app/src/hooks/useKeyImport.ts
@@ -39,15 +39,12 @@ export function parseKeyInput(input: string): KeyImportResult {
   if (lowerInput.startsWith("nsec")) {
     try {
       const decoded = nip19.decode(lowerInput);
-      if (decoded.type === "nsec") {
-        const privateKeyHex = bytesToHex(decoded.data);
-        return {
-          type: "nsec",
-          privateKeyHex,
-        };
-      } else {
-        throw new Error("Invalid nsec format");
-      }
+      // The checked nsec human-readable prefix determines the decoded type.
+      const privateKeyHex = bytesToHex(decoded.data as Uint8Array);
+      return {
+        type: "nsec",
+        privateKeyHex,
+      };
     } catch (error) {
       throw new Error(
         "That key format does not look right. Check and try again.",

--- a/nr-app/src/hooks/useKeyImport.ts
+++ b/nr-app/src/hooks/useKeyImport.ts
@@ -3,6 +3,7 @@ import { nip19 } from "nostr-tools";
 import { bytesToHex } from "@noble/hashes/utils";
 import { useAppDispatch } from "@/redux/hooks";
 import { setPrivateKeyPromiseAction } from "@/redux/sagas/keystore.saga";
+import { validateWords } from "nip06";
 
 type KeyImportResult =
   | {
@@ -20,17 +21,24 @@ type KeyImportResult =
  * @returns KeyImportResult with the parsed key data
  * @throws Error if the input is invalid
  */
-function parseKeyInput(input: string): KeyImportResult {
+export function parseKeyInput(input: string): KeyImportResult {
   const trimmedInput = input.trim();
+  const lowerInput = trimmedInput.toLowerCase();
 
   if (!trimmedInput) {
     throw new Error("Please enter a key");
   }
 
   // Handle nsec format
-  if (trimmedInput.startsWith("nsec")) {
+  if (lowerInput.startsWith("npub1")) {
+    throw new Error(
+      "That is a public npub address. Import your private nsec or recovery phrase instead.",
+    );
+  }
+
+  if (lowerInput.startsWith("nsec")) {
     try {
-      const decoded = nip19.decode(trimmedInput);
+      const decoded = nip19.decode(lowerInput);
       if (decoded.type === "nsec") {
         const privateKeyHex = bytesToHex(decoded.data);
         return {
@@ -47,10 +55,16 @@ function parseKeyInput(input: string): KeyImportResult {
     }
   }
 
-  // Handle mnemonic format
+  const mnemonic = lowerInput.split(/\s+/).join(" ");
+  if (!validateWords({ mnemonic }).isMnemonicValid) {
+    throw new Error(
+      "That recovery phrase is not valid. Check the words and their order.",
+    );
+  }
+
   return {
     type: "mnemonic",
-    mnemonic: trimmedInput,
+    mnemonic,
   };
 }
 

--- a/nr-app/src/index.ts
+++ b/nr-app/src/index.ts
@@ -1,19 +1,8 @@
 /* eslint-disable import/first */
-// import "polyfill"
-// import { getRandomValues } from "expo-crypto";
-import "react-native-get-random-values";
+import "@/secureRandom.bootstrap";
 
 import "fast-text-encoding";
 import "./MessageChannel.js";
-
-// Patch `crypto.getRandomValues()` for `nip06` which depends on `@scure/bip32`
-// which depends on `@noble/hashes/utils` which depends on
-// `@noble/hashes/crypto` which in turn checks for
-// `globalThis.crypto.getRandomBytes()` or `globalThis.crypto.getRandomValues()`
-// and throws if neither exist.
-// globalThis.crypto = {
-//   getRandomValues,
-// } as any;
 
 import { store } from "@/redux/store";
 import { injectStore } from "@/nostr/subscriptions.nostr";

--- a/nr-app/src/nostr/keystore.nostr.test.ts
+++ b/nr-app/src/nostr/keystore.nostr.test.ts
@@ -7,6 +7,7 @@ import {
   seedSecureStoreMock,
 } from "@/test/secureStoreMock";
 import { accountFromSeedWords } from "nip06";
+import * as SecureStore from "expo-secure-store";
 import {
   derivePublicKeyHexFromMnemonic,
   getHasPrivateKeyHexInSecureStorage,
@@ -80,6 +81,49 @@ describe("keystore.nostr", () => {
 
     await expect(getPrivateKeyHexFromSecureStorage()).rejects.toThrow(
       "#1RCMGy-invalid-key-retrieved",
+    );
+  });
+
+  it("uses the signing key as canonical if a stale mnemonic remains", async () => {
+    const account = accountFromSeedWords({ mnemonic });
+    seedSecureStoreMock({
+      [SECURE_STORE_PRIVATE_KEY_HEX_KEY]: account.privateKey.hex,
+      [SECURE_STORE_PRIVATE_KEY_HEX_MNEMONIC]:
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+    });
+
+    await expect(getPublicKeyHexFromSecureStorage()).resolves.toEqual({
+      hasMnemonicInSecureStorage: false,
+      publicKeyHex: account.publicKey.hex,
+    });
+    await expect(getHasPrivateKeyMnemonicInSecureStorage()).resolves.toBe(
+      false,
+    );
+  });
+
+  it("rolls back both values if replacing a mnemonic-backed key fails", async () => {
+    const oldAccount = accountFromSeedWords({ mnemonic });
+    seedSecureStoreMock({
+      [SECURE_STORE_PRIVATE_KEY_HEX_KEY]: oldAccount.privateKey.hex,
+      [SECURE_STORE_PRIVATE_KEY_HEX_MNEMONIC]: mnemonic,
+    });
+    const replacement =
+      "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const setItemAsync = SecureStore.setItemAsync as jest.MockedFunction<
+      typeof SecureStore.setItemAsync
+    >;
+    setItemAsync
+      .mockResolvedValueOnce()
+      .mockRejectedValueOnce(new Error("full"));
+
+    await expect(
+      setPrivateKeyInSecureStorage({ mnemonic: replacement }),
+    ).rejects.toThrow("full");
+    await expect(getPrivateKeyHexFromSecureStorage()).resolves.toBe(
+      oldAccount.privateKey.hex,
+    );
+    await expect(getPrivateKeyMnemonicFromSecureStorage()).resolves.toBe(
+      mnemonic,
     );
   });
 

--- a/nr-app/src/nostr/keystore.nostr.test.ts
+++ b/nr-app/src/nostr/keystore.nostr.test.ts
@@ -6,6 +6,7 @@ import {
   resetSecureStoreMock,
   seedSecureStoreMock,
 } from "@/test/secureStoreMock";
+import { hexToBytes } from "@noble/hashes/utils";
 import { accountFromSeedWords } from "nip06";
 import * as SecureStore from "expo-secure-store";
 import {
@@ -13,9 +14,15 @@ import {
   getHasPrivateKeyHexInSecureStorage,
   getHasPrivateKeyInSecureStorage,
   getHasPrivateKeyMnemonicInSecureStorage,
+  getPrivateKeyBytesFromSecureStorage,
   getPrivateKeyHexFromSecureStorage,
   getPrivateKeyMnemonicFromSecureStorage,
   getPublicKeyHexFromSecureStorage,
+  getPublicKeyHexStringFromSecureStorage,
+  nip04Decrypt,
+  nip04Encrypt,
+  nip44Decrypt,
+  nip44Encrypt,
   setPrivateKeyInSecureStorage,
   signEventTemplate,
 } from "./keystore.nostr";
@@ -34,6 +41,7 @@ describe("keystore.nostr", () => {
     await expect(getHasPrivateKeyMnemonicInSecureStorage()).resolves.toBe(
       false,
     );
+    await expect(getPublicKeyHexFromSecureStorage()).resolves.toBeUndefined();
   });
 
   it("stores and retrieves mnemonic-backed keys", async () => {
@@ -49,6 +57,14 @@ describe("keystore.nostr", () => {
     await expect(getPrivateKeyHexFromSecureStorage()).resolves.toBe(
       account.privateKey.hex,
     );
+    await expect(getPrivateKeyBytesFromSecureStorage()).resolves.toEqual(
+      hexToBytes(account.privateKey.hex),
+    );
+    await expect(getPublicKeyHexStringFromSecureStorage()).resolves.toBe(
+      account.publicKey.hex,
+    );
+    await expect(getHasPrivateKeyHexInSecureStorage()).resolves.toBe(true);
+    await expect(getHasPrivateKeyInSecureStorage()).resolves.toBe(true);
     await expect(getPublicKeyHexFromSecureStorage()).resolves.toEqual({
       hasMnemonicInSecureStorage: true,
       publicKeyHex: account.publicKey.hex,
@@ -127,6 +143,20 @@ describe("keystore.nostr", () => {
     );
   });
 
+  it("removes partially written values when an initial save fails", async () => {
+    const setItemAsync = SecureStore.setItemAsync as jest.MockedFunction<
+      typeof SecureStore.setItemAsync
+    >;
+    setItemAsync
+      .mockResolvedValueOnce()
+      .mockRejectedValueOnce(new Error("full"));
+
+    await expect(setPrivateKeyInSecureStorage({ mnemonic })).rejects.toThrow(
+      "full",
+    );
+    await expect(getHasPrivateKeyInSecureStorage()).resolves.toBe(false);
+  });
+
   it("derives public keys from mnemonics", () => {
     const account = accountFromSeedWords({ mnemonic });
 
@@ -151,5 +181,36 @@ describe("keystore.nostr", () => {
       kind: 1,
       pubkey: account.publicKey.hex,
     });
+  });
+
+  it("encrypts and decrypts NIP-04 and NIP-44 messages", async () => {
+    const account = accountFromSeedWords({ mnemonic });
+    await setPrivateKeyInSecureStorage({ mnemonic });
+    const peerPubkey = account.publicKey.hex;
+
+    const nip44Ciphertext = await nip44Encrypt(peerPubkey, "nip44 secret");
+    await expect(nip44Decrypt(peerPubkey, nip44Ciphertext)).resolves.toBe(
+      "nip44 secret",
+    );
+
+    const nip04Ciphertext = await nip04Encrypt(peerPubkey, "nip04 secret");
+    await expect(nip04Decrypt(peerPubkey, nip04Ciphertext)).resolves.toBe(
+      "nip04 secret",
+    );
+  });
+
+  it("rejects invalid peer keys for every encryption operation", async () => {
+    await expect(nip44Encrypt("invalid", "plaintext")).rejects.toThrow(
+      "Invalid peer public key.",
+    );
+    await expect(nip44Decrypt("invalid", "ciphertext")).rejects.toThrow(
+      "Invalid peer public key.",
+    );
+    await expect(nip04Encrypt("invalid", "plaintext")).rejects.toThrow(
+      "Invalid peer public key.",
+    );
+    await expect(nip04Decrypt("invalid", "ciphertext")).rejects.toThrow(
+      "Invalid peer public key.",
+    );
   });
 });

--- a/nr-app/src/nostr/keystore.nostr.ts
+++ b/nr-app/src/nostr/keystore.nostr.ts
@@ -68,16 +68,11 @@ export async function getHasPrivateKeyHexInSecureStorage(): Promise<boolean> {
 }
 
 export async function getHasPrivateKeyInSecureStorage(): Promise<boolean> {
-  try {
-    const hasMnemonic = await getHasPrivateKeyMnemonicInSecureStorage();
-    if (hasMnemonic) {
-      return true;
-    }
-    const hasHex = await getHasPrivateKeyHexInSecureStorage();
-    return hasHex;
-  } catch {
-    return false;
+  const hasMnemonic = await getHasPrivateKeyMnemonicInSecureStorage();
+  if (hasMnemonic) {
+    return true;
   }
+  return getHasPrivateKeyHexInSecureStorage();
 }
 
 export async function getPublicKeyHexFromSecureStorage(): Promise<

--- a/nr-app/src/nostr/keystore.nostr.ts
+++ b/nr-app/src/nostr/keystore.nostr.ts
@@ -51,10 +51,8 @@ export async function getPrivateKeyMnemonicFromSecureStorage(): Promise<string> 
 export async function getHasPrivateKeyMnemonicInSecureStorage(): Promise<boolean> {
   try {
     const mnemonic = await getPrivateKeyMnemonicFromSecureStorage();
-    if (typeof mnemonic === "string" && mnemonic.length > 10) {
-      return true;
-    }
-    return false;
+    const privateKeyHex = await getPrivateKeyHexFromSecureStorage();
+    return accountFromSeedWords({ mnemonic }).privateKey.hex === privateKeyHex;
   } catch {
     return false;
   }
@@ -90,26 +88,20 @@ export async function getPublicKeyHexFromSecureStorage(): Promise<
   | undefined
 > {
   try {
-    const hasMnemonic = await getHasPrivateKeyMnemonicInSecureStorage();
-    if (hasMnemonic) {
+    const privateKeyHex = await getPrivateKeyHexFromSecureStorage();
+    const publicKeyHex = getPublicKey(hexToBytes(privateKeyHex));
+    let hasMatchingMnemonic = false;
+
+    if (await getHasPrivateKeyMnemonicInSecureStorage()) {
       const mnemonic = await getPrivateKeyMnemonicFromSecureStorage();
       const account = accountFromSeedWords({ mnemonic });
-      return {
-        hasMnemonicInSecureStorage: true,
-        publicKeyHex: account.publicKey.hex,
-      };
-    } else {
-      const hasPrivateKeyHex = await getHasPrivateKeyHexInSecureStorage();
-      if (!hasPrivateKeyHex) {
-        return;
-      }
-      const privateKeyHexBytes = await getPrivateKeyBytesFromSecureStorage();
-      const publicKeyHex = getPublicKey(privateKeyHexBytes);
-      return {
-        hasMnemonicInSecureStorage: false,
-        publicKeyHex,
-      };
+      hasMatchingMnemonic = account.privateKey.hex === privateKeyHex;
     }
+
+    return {
+      hasMnemonicInSecureStorage: hasMatchingMnemonic,
+      publicKeyHex,
+    };
   } catch {
     // TODO: handle error
   }
@@ -123,36 +115,61 @@ export async function getPublicKeyHexStringFromSecureStorage(): Promise<string> 
 export async function setPrivateKeyInSecureStorage(
   input: { mnemonic: string } | { privateKeyHex: string },
 ) {
+  const previousPrivateKey = await SecureStore.getItemAsync(
+    SECURE_STORE_PRIVATE_KEY_HEX_KEY,
+  );
+  const previousMnemonic = await SecureStore.getItemAsync(
+    SECURE_STORE_PRIVATE_KEY_HEX_MNEMONIC,
+  );
+
+  let mnemonic: string | undefined;
+  let privateKeyHex: string;
   if ("mnemonic" in input) {
-    const { mnemonic } = input;
-    const account = accountFromSeedWords({ mnemonic: mnemonic });
-    await SecureStore.setItemAsync(
-      SECURE_STORE_PRIVATE_KEY_HEX_MNEMONIC,
-      mnemonic,
-      SecureStoreKeySettings,
-    );
+    mnemonic = input.mnemonic;
+    privateKeyHex = accountFromSeedWords({ mnemonic }).privateKey.hex;
+  } else {
+    privateKeyHex = input.privateKeyHex;
+  }
+  const publicKeyHex = getPublicKey(hexToBytes(privateKeyHex));
+
+  try {
     await SecureStore.setItemAsync(
       SECURE_STORE_PRIVATE_KEY_HEX_KEY,
-      account.privateKey.hex,
+      privateKeyHex,
       SecureStoreKeySettings,
     );
-    return account.publicKey.hex;
-  } else {
-    const { privateKeyHex } = input;
-    const privateKeyHexBytes = hexToBytes(privateKeyHex);
-    try {
-      const publicKeyHex = getPublicKey(privateKeyHexBytes);
-      await SecureStore.deleteItemAsync(SECURE_STORE_PRIVATE_KEY_HEX_MNEMONIC);
+
+    if (mnemonic) {
       await SecureStore.setItemAsync(
-        SECURE_STORE_PRIVATE_KEY_HEX_KEY,
-        privateKeyHex,
+        SECURE_STORE_PRIVATE_KEY_HEX_MNEMONIC,
+        mnemonic,
         SecureStoreKeySettings,
       );
-      return publicKeyHex;
-    } catch (error) {
-      console.error("#85VtuH got error", error);
-      throw error;
+    } else {
+      await SecureStore.deleteItemAsync(SECURE_STORE_PRIVATE_KEY_HEX_MNEMONIC);
     }
+
+    return publicKeyHex;
+  } catch (error) {
+    await Promise.allSettled([
+      restoreSecureStoreValue(
+        SECURE_STORE_PRIVATE_KEY_HEX_KEY,
+        previousPrivateKey,
+      ),
+      restoreSecureStoreValue(
+        SECURE_STORE_PRIVATE_KEY_HEX_MNEMONIC,
+        previousMnemonic,
+      ),
+    ]);
+    throw error;
+  }
+}
+
+async function restoreSecureStoreValue(key: string, value: string | null) {
+  if (value === null) {
+    await SecureStore.deleteItemAsync(key);
+  } else {
+    await SecureStore.setItemAsync(key, value, SecureStoreKeySettings);
   }
 }
 

--- a/nr-app/src/secureRandom.bootstrap.ts
+++ b/nr-app/src/secureRandom.bootstrap.ts
@@ -1,0 +1,7 @@
+import { getRandomValues } from "expo-crypto";
+import { installSecureRandom } from "./secureRandom";
+
+// Install Expo Crypto before key modules load so generation uses the native OS
+// CSPRNG and fails closed if it is unavailable. Do not use the React Native
+// shim here: it deliberately falls back to `Math.random()` while debugging.
+installSecureRandom(getRandomValues as Crypto["getRandomValues"]);

--- a/nr-app/src/secureRandom.test.ts
+++ b/nr-app/src/secureRandom.test.ts
@@ -64,7 +64,7 @@ describe("secure random bootstrap", () => {
     }) as unknown as Crypto["getRandomValues"];
     installSecureRandom(secureGetRandomValues);
 
-    let generateSeedWords!: typeof import("nip06")["generateSeedWords"];
+    let generateSeedWords!: (typeof import("nip06"))["generateSeedWords"];
     jest.isolateModules(() => {
       ({ generateSeedWords } = require("nip06") as typeof import("nip06"));
       expect(generateSeedWords().mnemonic.split(" ")).toHaveLength(12);

--- a/nr-app/src/secureRandom.test.ts
+++ b/nr-app/src/secureRandom.test.ts
@@ -1,0 +1,52 @@
+import { installSecureRandom } from "./secureRandom";
+
+describe("secure random bootstrap", () => {
+  const originalCrypto = globalThis.crypto;
+  const originalGetRandomValues = originalCrypto?.getRandomValues;
+
+  afterEach(() => {
+    if (originalCrypto && originalGetRandomValues) {
+      originalCrypto.getRandomValues = originalGetRandomValues;
+    }
+    globalThis.crypto = originalCrypto;
+    jest.resetModules();
+  });
+
+  it("replaces the captured random function on the existing crypto object", () => {
+    const capturedCrypto = {
+      getRandomValues: jest.fn(),
+    } as unknown as Crypto;
+    globalThis.crypto = capturedCrypto;
+    const secureGetRandomValues = jest.fn(
+      (array) => array,
+    ) as unknown as Crypto["getRandomValues"];
+
+    installSecureRandom(secureGetRandomValues);
+
+    expect(globalThis.crypto).toBe(capturedCrypto);
+    expect(capturedCrypto.getRandomValues).toBe(secureGetRandomValues);
+  });
+
+  it("requests 128 bits and propagates generator failures without fallback", () => {
+    const byteLengths: number[] = [];
+    const secureGetRandomValues = jest.fn((array: ArrayBufferView) => {
+      byteLengths.push(array.byteLength);
+      new Uint8Array(array.buffer, array.byteOffset, array.byteLength).fill(7);
+      return array;
+    }) as unknown as Crypto["getRandomValues"];
+    installSecureRandom(secureGetRandomValues);
+
+    let generateSeedWords!: typeof import("nip06")["generateSeedWords"];
+    jest.isolateModules(() => {
+      ({ generateSeedWords } = require("nip06") as typeof import("nip06"));
+      expect(generateSeedWords().mnemonic.split(" ")).toHaveLength(12);
+    });
+    expect(byteLengths).toEqual([16]);
+
+    const unavailable = jest.fn(() => {
+      throw new Error("native CSPRNG unavailable");
+    }) as unknown as Crypto["getRandomValues"];
+    installSecureRandom(unavailable);
+    expect(() => generateSeedWords()).toThrow("native CSPRNG unavailable");
+  });
+});

--- a/nr-app/src/secureRandom.test.ts
+++ b/nr-app/src/secureRandom.test.ts
@@ -27,6 +27,34 @@ describe("secure random bootstrap", () => {
     expect(capturedCrypto.getRandomValues).toBe(secureGetRandomValues);
   });
 
+  it("creates the crypto object when the runtime does not provide one", () => {
+    globalThis.crypto = undefined as unknown as Crypto;
+    const secureGetRandomValues = jest.fn(
+      (array) => array,
+    ) as unknown as Crypto["getRandomValues"];
+
+    installSecureRandom(secureGetRandomValues);
+
+    expect(globalThis.crypto.getRandomValues).toBe(secureGetRandomValues);
+  });
+
+  it("installs Expo's native generator during bootstrap", () => {
+    const nativeGetRandomValues = jest.fn();
+    const install = jest.fn();
+
+    jest.isolateModules(() => {
+      jest.doMock("expo-crypto", () => ({
+        getRandomValues: nativeGetRandomValues,
+      }));
+      jest.doMock("./secureRandom", () => ({ installSecureRandom: install }));
+      require("./secureRandom.bootstrap");
+    });
+
+    expect(install).toHaveBeenCalledWith(nativeGetRandomValues);
+    jest.dontMock("expo-crypto");
+    jest.dontMock("./secureRandom");
+  });
+
   it("requests 128 bits and propagates generator failures without fallback", () => {
     const byteLengths: number[] = [];
     const secureGetRandomValues = jest.fn((array: ArrayBufferView) => {

--- a/nr-app/src/secureRandom.ts
+++ b/nr-app/src/secureRandom.ts
@@ -1,0 +1,10 @@
+export function installSecureRandom(
+  getRandomValues: Crypto["getRandomValues"],
+): void {
+  const crypto = globalThis.crypto ?? ({} as Crypto);
+
+  // Mutate the existing object so crypto libraries that captured its reference
+  // during module loading also receive the secure implementation.
+  crypto.getRandomValues = getRandomValues;
+  globalThis.crypto = crypto;
+}

--- a/nr-server/main.ts
+++ b/nr-server/main.ts
@@ -2,21 +2,7 @@ import { cliffy, nostrTools } from "./deps.ts";
 import { consume } from "./src/consume.ts";
 import { log } from "./src/log.ts";
 import { subscribeAndRepost } from "./src/subscribe.ts";
-
-function getOrCreatePrivateKey(maybePrivateKeyNsec?: string) {
-  if (typeof maybePrivateKeyNsec === "string") {
-    const decoded = nostrTools.nip19.decode(maybePrivateKeyNsec);
-    if (decoded.type !== "nsec") {
-      throw new Error("#5jLJ2W Invalid nsec");
-    }
-    return decoded.data;
-  }
-
-  const key = nostrTools.generateSecretKey();
-  const nsec = nostrTools.nip19.nsecEncode(key);
-  log.info(`#2yrJza Using random nsec ${nsec}`);
-  return key;
-}
+import { resolvePrivateKey } from "./src/private-key.ts";
 
 await new cliffy.Command()
   .globalEnv("IS_DEV", "Set to true to run in development mode")
@@ -38,7 +24,15 @@ await new cliffy.Command()
   )
   .action(async (options) => {
     const { isDev } = options;
-    const privateKey = getOrCreatePrivateKey(options.privateKeyNsec);
+    const resolvedPrivateKey = resolvePrivateKey(
+      options.privateKeyNsec,
+      isDev === true || String(isDev).toLowerCase() === "true",
+    );
+    const privateKey = resolvedPrivateKey.key;
+    if (resolvedPrivateKey.generatedForDevelopment) {
+      const publicKey = nostrTools.getPublicKey(privateKey);
+      log.info(`#2yrJza Using ephemeral development pubkey ${publicKey}`);
+    }
     const maxAgeMinutes = options.maxAgeMinutes;
 
     log.debug(

--- a/nr-server/src/private-key.test.ts
+++ b/nr-server/src/private-key.test.ts
@@ -45,3 +45,23 @@ Deno.test("private key configuration preserves a configured nsec", () => {
     "expected configured secret bytes",
   );
 });
+
+Deno.test("private key configuration rejects public npub values", () => {
+  const publicKey = nostrTools.getPublicKey(nostrTools.generateSecretKey());
+  const npub = nostrTools.nip19.npubEncode(publicKey);
+
+  let thrown: unknown;
+  try {
+    resolvePrivateKey(npub, false);
+  } catch (error) {
+    thrown = error;
+  }
+  assert(thrown instanceof Error, "expected npub configuration to throw");
+  assert(thrown.message.includes("Invalid nsec"), "expected nsec error");
+});
+
+Deno.test("blank development configuration creates an ephemeral key", () => {
+  const resolved = resolvePrivateKey("   ", true);
+  assert(resolved.generatedForDevelopment, "expected development marker");
+  assert(resolved.key.length === 32, "expected 32-byte secret key");
+});

--- a/nr-server/src/private-key.test.ts
+++ b/nr-server/src/private-key.test.ts
@@ -1,0 +1,47 @@
+import { nostrTools } from "../deps.ts";
+import { resolvePrivateKey } from "./private-key.ts";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+Deno.test(
+  "private key configuration requires an explicit production key",
+  () => {
+    let thrown: unknown;
+    try {
+      resolvePrivateKey(undefined, false);
+    } catch (error) {
+      thrown = error;
+    }
+    assert(thrown instanceof Error, "expected missing production key to throw");
+    assert(thrown.message.includes("required"), "expected actionable error");
+  },
+);
+
+Deno.test(
+  "private key configuration may create an ephemeral development key",
+  () => {
+    const resolved = resolvePrivateKey(undefined, true);
+    assert(resolved.generatedForDevelopment, "expected development marker");
+    assert(resolved.key.length === 32, "expected 32-byte secret key");
+    assert(
+      nostrTools.getPublicKey(resolved.key).length === 64,
+      "expected valid scalar",
+    );
+  },
+);
+
+Deno.test("private key configuration preserves a configured nsec", () => {
+  const expected = nostrTools.generateSecretKey();
+  const nsec = nostrTools.nip19.nsecEncode(expected);
+  const resolved = resolvePrivateKey(nsec, false);
+  assert(
+    !resolved.generatedForDevelopment,
+    "configured keys are not ephemeral",
+  );
+  assert(
+    resolved.key.every((byte, index) => byte === expected[index]),
+    "expected configured secret bytes",
+  );
+});

--- a/nr-server/src/private-key.ts
+++ b/nr-server/src/private-key.ts
@@ -1,0 +1,34 @@
+import { nostrTools } from "../deps.ts";
+
+export type ResolvedPrivateKey = {
+  key: Uint8Array;
+  generatedForDevelopment: boolean;
+};
+
+export function resolvePrivateKey(
+  maybePrivateKeyNsec: string | undefined,
+  isDev: boolean,
+): ResolvedPrivateKey {
+  if (typeof maybePrivateKeyNsec === "string" && maybePrivateKeyNsec.trim()) {
+    const decoded = nostrTools.nip19.decode(maybePrivateKeyNsec.trim());
+    if (decoded.type !== "nsec") {
+      throw new Error("#5jLJ2W Invalid nsec");
+    }
+
+    // Decoding proves the NIP-19 checksum, while getPublicKey also proves that
+    // the 32-byte payload is a valid secp256k1 scalar.
+    nostrTools.getPublicKey(decoded.data);
+    return { key: decoded.data, generatedForDevelopment: false };
+  }
+
+  if (!isDev) {
+    throw new Error(
+      "PRIVATE_KEY_NSEC is required outside development; refusing to generate an ephemeral signing identity.",
+    );
+  }
+
+  return {
+    key: nostrTools.generateSecretKey(),
+    generatedForDevelopment: true,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,9 +180,6 @@ importers:
       react-native-gesture-handler:
         specifier: ~2.31.2
         version: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.16)(react@19.2.3))(react@19.2.3)
-      react-native-get-random-values:
-        specifier: ^1.11.0
-        version: 1.11.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.16)(react@19.2.3))
       react-native-keyboard-controller:
         specifier: ^1.21.6
         version: 1.21.6(react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.16)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.16)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.16)(react@19.2.3))(react@19.2.3)
@@ -3745,9 +3742,6 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
-  fast-base64-decode@1.0.0:
-    resolution: {integrity: sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==}
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -5550,11 +5544,6 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
-
-  react-native-get-random-values@1.11.0:
-    resolution: {integrity: sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==}
-    peerDependencies:
-      react-native: '>=0.56'
 
   react-native-is-edge-to-edge@1.2.1:
     resolution: {integrity: sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==}
@@ -10912,8 +10901,6 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
-  fast-base64-decode@1.0.0: {}
-
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -12965,11 +12952,6 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.16)(react@19.2.3)
-
-  react-native-get-random-values@1.11.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.16)(react@19.2.3)):
-    dependencies:
-      fast-base64-decode: 1.0.0
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.16)(react@19.2.3)
 
   react-native-is-edge-to-edge@1.2.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.16)(react@19.2.3))(react@19.2.3):


### PR DESCRIPTION
## Summary

- install the Expo Crypto native CSPRNG before mobile key modules load and remove the debug-capable random shim
- validate mnemonic and nsec imports, reject public-only npub input, and normalize accepted input
- wait for key persistence and roll back partial SecureStore replacements
- require an explicit validation-server signing key outside development and avoid logging private keys
- document the repository-wide key-generation inventory, entropy assessment, and remaining storage recommendations
- enforce 100% statement, branch, function, and line coverage for the mobile key-generation/import/keystore core

The corresponding Vibe mnemonic/scalar updates are already on `main` in `6a7b486b`.

## Randomness

Mobile 12-word phrases request exactly 16 bytes (128 bits) from the Expo Crypto OS-backed generator. The bootstrap fails closed if native secure randomness is unavailable; it has no `Math.random()` fallback. Direct Nostr secret generators use valid 256-bit secp256k1 scalars.

## Compatibility

Existing persisted mobile keys are unchanged. Invalid BIP-39 phrases and public-only `npub` values are now rejected during private-key import.

## Tests

- mobile key coverage: 19 tests passing; 100% statements, branches, functions, and lines across the CSPRNG bootstrap, key parser, and secure keystore
- validation-server resolver: 5 tests passing; 100% branch, function, and line coverage