### PR TITLE
Add verified HTTPS onboarding links

### DIFF
--- a/nr-app/app.json
+++ b/nr-app/app.json
@@ -11,6 +11,7 @@
       "supportsTablet": true,
       "bundleIdentifier": "org.trustroots.nostroots",
       "appleTeamId": "WR2T34P467",
+      "associatedDomains": ["applinks:nos.trustroots.org"],
       "config": {
         "usesNonExemptEncryption": false
       },
@@ -29,6 +30,25 @@
         "android.permission.ACCESS_FINE_LOCATION"
       ],
       "package": "org.trustroots.nostroots",
+      "intentFilters": [
+        {
+          "action": "VIEW",
+          "autoVerify": true,
+          "data": [
+            {
+              "scheme": "https",
+              "host": "nos.trustroots.org",
+              "path": "/open/onboarding"
+            },
+            {
+              "scheme": "https",
+              "host": "nos.trustroots.org",
+              "path": "/open/onboarding/"
+            }
+          ],
+          "category": ["BROWSABLE", "DEFAULT"]
+        }
+      ],
       "googleServicesFile": "./google-services.json"
     },
     "web": {

--- a/nr-app/app/onboarding/trustroots.tsx
+++ b/nr-app/app/onboarding/trustroots.tsx
@@ -70,7 +70,10 @@ function getRequestErrorMessage(error: unknown): string {
 export default function OnboardingTrustrootsScreen() {
   const dispatch = useAppDispatch();
   const router = useRouter();
-  const { error: errorParam } = useLocalSearchParams<{ error?: string }>();
+  const { error: errorParam, username: usernameParam } = useLocalSearchParams<{
+    error?: string;
+    username?: string;
+  }>();
 
   const pendingTrustrootsUsername = useAppSelector(
     settingsSelectors.selectPendingTrustrootsUsername,
@@ -78,6 +81,12 @@ export default function OnboardingTrustrootsScreen() {
   const pendingTrustrootsProfileUsername = useAppSelector(
     settingsSelectors.selectPendingTrustrootsProfileUsername,
   );
+  const linkedUsernameResult = usernameParam
+    ? validateTrustrootsUsername(usernameParam)
+    : null;
+  const linkedUsername = linkedUsernameResult?.success
+    ? linkedUsernameResult.username
+    : null;
 
   const [screenState, setScreenState] = useState<TrustrootsScreenState>(
     pendingTrustrootsProfileUsername
@@ -87,7 +96,10 @@ export default function OnboardingTrustrootsScreen() {
         : "idle",
   );
   const [usernameInput, setUsernameInput] = useState(
-    pendingTrustrootsProfileUsername ?? pendingTrustrootsUsername ?? "",
+    pendingTrustrootsProfileUsername ??
+      pendingTrustrootsUsername ??
+      linkedUsername ??
+      "",
   );
   const [code, setCode] = useState("");
   const [fieldError, setFieldError] = useState<string | null>(null);

--- a/nr-app/app/open/onboarding.tsx
+++ b/nr-app/app/open/onboarding.tsx
@@ -1,0 +1,14 @@
+import { Redirect, useLocalSearchParams } from "expo-router";
+
+export default function OpenOnboardingRoute() {
+  const { username } = useLocalSearchParams<{ username?: string }>();
+
+  return (
+    <Redirect
+      href={{
+        pathname: "/onboarding/trustroots",
+        params: username ? { username } : undefined,
+      }}
+    />
+  );
+}

--- a/nr-app/src/test/routes/onboarding/trustroots.test.tsx
+++ b/nr-app/src/test/routes/onboarding/trustroots.test.tsx
@@ -27,6 +27,16 @@ const bridge = jest.requireMock("@/services/nrBridge.service") as {
 };
 
 describe("OnboardingTrustrootsScreen", () => {
+  it("pre-fills a valid username from an onboarding link", () => {
+    renderWithProviders(<OnboardingTrustrootsScreen />, {
+      searchParams: { username: "Guaka" },
+    });
+
+    expect(screen.getByPlaceholderText("your-username").props.value).toBe(
+      "guaka",
+    );
+  });
+
   it("validates username before requesting a code", () => {
     renderWithProviders(<OnboardingTrustrootsScreen />);
 

--- a/nr-app/src/test/routes/open/onboarding.test.tsx
+++ b/nr-app/src/test/routes/open/onboarding.test.tsx
@@ -1,0 +1,24 @@
+import { renderWithProviders } from "@/test/render";
+import OpenOnboardingRoute from "../../../../app/open/onboarding";
+
+describe("OpenOnboardingRoute", () => {
+  it("opens Trustroots onboarding and preserves the username", () => {
+    const { router } = renderWithProviders(<OpenOnboardingRoute />, {
+      searchParams: { username: "guaka" },
+    });
+
+    expect(router.replace).toHaveBeenCalledWith({
+      pathname: "/onboarding/trustroots",
+      params: { username: "guaka" },
+    });
+  });
+
+  it("opens Trustroots onboarding without requiring a username", () => {
+    const { router } = renderWithProviders(<OpenOnboardingRoute />);
+
+    expect(router.replace).toHaveBeenCalledWith({
+      pathname: "/onboarding/trustroots",
+      params: undefined,
+    });
+  });
+});

--- a/vibe/openspec/specs/vibe-web/spec.md
+++ b/vibe/openspec/specs/vibe-web/spec.md
@@ -69,6 +69,22 @@ step for the main pages.
 - **AND** it MUST explain that custom-scheme links do not install the app or
   provide an automatic website fallback.
 
+#### Scenario: Verified HTTPS onboarding fallback
+
+- **GIVEN** a member opens `/open/onboarding?username=<username>` without a
+  verified Nostroots app handling the URL
+- **WHEN** the static fallback page renders
+- **THEN** it MUST explain that the link continues Trustroots onboarding in the
+  installed Nostroots app
+- **AND** on Android it MUST continue to the official Google Play listing
+- **AND** on iPhone or iPad it MUST continue to the official App Store listing
+- **AND** on desktop or an unknown device it MUST offer both store listings
+- **AND** the desktop fallback MUST also offer the Android APK releases and the
+  existing generic app-download QR code
+- **AND** it MUST preserve the username only as visible, non-secret context
+- **AND** the site MUST publish platform association files that restrict native
+  handling to the Nostroots app identity and `/open/onboarding` path.
+
 ### Requirement: Single canonical browser map surface
 
 Vibe Web MUST provide `/web/` as the only maintained Nostroots browser

--- a/vibe/web/.well-known/apple-app-site-association
+++ b/vibe/web/.well-known/apple-app-site-association
@@ -1,0 +1,21 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": [
+          "WR2T34P467.org.trustroots.nostroots"
+        ],
+        "components": [
+          {
+            "/": "/open/onboarding",
+            "comment": "Open Trustroots onboarding in Nostroots"
+          },
+          {
+            "/": "/open/onboarding/",
+            "comment": "Open the static fallback form of the onboarding URL in Nostroots"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/vibe/web/.well-known/assetlinks.json
+++ b/vibe/web/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "org.trustroots.nostroots",
+      "sha256_cert_fingerprints": [
+        "61:A4:B6:6E:1B:B0:75:4A:D2:2D:58:25:9E:FF:35:E7:F8:E9:EF:44:3E:C0:BD:83:3A:A4:A5:1A:5F:86:8F:8B"
+      ]
+    }
+  }
+]

--- a/vibe/web/README.md
+++ b/vibe/web/README.md
@@ -10,6 +10,7 @@ The root page is a small hub. It links to classic Trustroots network settings, N
 
 - [`/background/`](background/) — background, vision, and FAQ for Nostroots and the Trustroots/Nostr direction.
 - [`/test/`](test/) — mobile-friendly manual test for opening the installed app with `nostroots://` links.
+- [`/open/onboarding`](open/onboarding/) — verified HTTPS onboarding link and app-store fallback page.
 - [`https://www.trustroots.org/profile/edit/networks`](https://www.trustroots.org/profile/edit/networks) — classic Trustroots network editing.
 - [`/web/`](web/) — Nostroots Web, the canonical map/chat/profile app for Trustroots-style activity with light Nostr key support.
 - [`/nostrail/`](nostrail/) — experimental foreground-only encrypted approximate-location sharing for Nostroots Browser.
@@ -87,6 +88,35 @@ See [`../docs/RELAY_SCOPE_UI.md`](../docs/RELAY_SCOPE_UI.md) for how `relayScope
 See [`../docs/TRUSTROOTS_MAP_NOTES.md`](../docs/TRUSTROOTS_MAP_NOTES.md) for the dual map-note trust model in this repo: `30397 -> nr-server -> 30398` and the nr-web auth-relay path (`wss://nip42.trustroots.org` + NIP-42) where `30397` is treated as Trustroots-scoped in product behavior.
 
 ### Testing
+
+#### Verified onboarding links
+
+The public onboarding URL is `https://nos.trustroots.org/open/onboarding?username=guaka`.
+iPhone and iPad browser fallbacks continue to the App Store, Android fallbacks
+continue to Google Play, and desktop/unknown clients show both store choices,
+the Android APK releases, and the generic app-download QR code.
+iOS Universal Links are associated with Apple Team ID `WR2T34P467`; Android
+App Links are currently associated with the certificate used to sign the
+official GitHub preview APK. Before relying on links for Google Play installs,
+add the SHA-256 fingerprint from **Play Console → Setup → App integrity → App
+signing key certificate** to `.well-known/assetlinks.json` as a second entry in
+`sha256_cert_fingerprints`. Google Play App Signing uses a different certificate
+from the upload/direct-distribution key.
+
+Only public, low-sensitivity context such as a Trustroots username belongs in
+this URL. Authenticated handoff must use a short-lived, single-use authorization
+code, ideally bound to the app with PKCE; never include an nsec, session cookie,
+permanent API token, or email-verification code.
+
+Content links can extend the same verified-link family with allowlisted paths,
+for example `/open/event/<event-id>?username=guaka`. The path is the destination
+and the optional query parameter is onboarding context; do not accept an
+arbitrary destination URL. The app should remember a supported destination
+while onboarding and continue there afterwards. A fallback-page QR code must
+encode the complete content URL to preserve both values. Store installation
+does not by itself restore the original link on iOS, so the first version should
+ask members to return to the original Trustroots link after installing. Android
+can optionally add Play Install Referrer support as a later enhancement.
 
 The repo still iterates quickly on `nr-web`: tests exist to guard important behavior, not to drive every small UI change. Prefer meaningful coverage over a large suite; run the stack when you are changing critical paths or preparing to merge.
 

--- a/vibe/web/open/onboarding/index.html
+++ b/vibe/web/open/onboarding/index.html
@@ -1,0 +1,225 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#08261f" />
+    <meta
+      name="description"
+      content="Continue Trustroots onboarding in the Nostroots app."
+    />
+    <link rel="canonical" href="https://nos.trustroots.org/open/onboarding" />
+    <title>Continue in Nostroots</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font:
+          16px/1.5 system-ui,
+          sans-serif;
+        --ink: #08261f;
+        --muted: #52635e;
+        --panel: #fffdf4;
+        --accent: #007f6e;
+        --border: rgba(0, 75, 63, 0.16);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background:
+          linear-gradient(180deg, rgba(152, 173, 70, 0.2), transparent 360px),
+          #f5f1e3;
+        color: var(--ink);
+      }
+
+      main {
+        width: min(34rem, calc(100% - 32px));
+        margin: 32px auto;
+        padding: clamp(28px, 7vw, 48px);
+        border: 1px solid var(--border);
+        border-radius: 22px;
+        background: var(--panel);
+        box-shadow: 0 18px 48px rgba(0, 75, 63, 0.12);
+        text-align: center;
+      }
+
+      .brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+        color: var(--ink);
+        font-weight: 800;
+        text-decoration: none;
+      }
+
+      .brand img {
+        border-radius: 12px;
+      }
+
+      h1 {
+        margin: 28px 0 10px;
+        font-size: clamp(2rem, 8vw, 3rem);
+        line-height: 1.08;
+      }
+
+      .lead {
+        margin: 0;
+        color: var(--muted);
+        font-size: 1.08rem;
+      }
+
+      .username {
+        margin: 20px 0 0;
+        font-weight: 750;
+      }
+
+      .stores {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+        margin-top: 28px;
+      }
+
+      .store-link {
+        display: grid;
+        min-height: 50px;
+        place-items: center;
+        padding: 0 18px;
+        border-radius: 999px;
+        background: var(--accent);
+        color: white;
+        font-weight: 800;
+        text-decoration: none;
+      }
+
+      .apk-link {
+        display: inline-block;
+        margin-top: 14px;
+        color: var(--accent);
+        font-weight: 750;
+      }
+
+      .qr {
+        display: block;
+        width: 144px;
+        height: 144px;
+        margin: 26px auto 0;
+        padding: 8px;
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        background: white;
+      }
+
+      .qr img {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+
+      .scan {
+        margin: 8px 0 0;
+        color: var(--muted);
+        font-size: 0.88rem;
+      }
+
+      .help {
+        margin: 24px 0 0;
+        color: var(--muted);
+        font-size: 0.92rem;
+      }
+
+      .home {
+        display: inline-block;
+        margin-top: 22px;
+        color: var(--accent);
+        font-weight: 700;
+      }
+
+      @media (max-width: 480px) {
+        .stores {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <a class="brand" href="../../">
+        <img src="../../nostroots-logo67.png" alt="" width="48" height="48" />
+        Nostroots
+      </a>
+      <h1>Continue in Nostroots</h1>
+      <p class="lead">
+        This link opens Trustroots onboarding in the Nostroots app when it is
+        installed.
+      </p>
+      <p class="username" id="username" hidden></p>
+
+      <div class="stores" aria-label="Install Nostroots">
+        <a
+          class="store-link"
+          href="https://play.google.com/store/apps/details?id=org.trustroots.nostroots"
+          >Get it on Google Play</a
+        >
+        <a
+          class="store-link"
+          href="https://apps.apple.com/app/nostroots/id6755037304"
+          >Get it on the App Store</a
+        >
+      </div>
+      <a
+        class="apk-link"
+        href="https://github.com/Trustroots/nostroots/releases/"
+        >Download the Android APK</a
+      >
+
+      <a class="qr" href="../../app/" aria-label="Open app download page">
+        <img
+          src="../../app-qr.svg"
+          alt="Nostroots app download QR code"
+          width="128"
+          height="128"
+        />
+      </a>
+      <p class="scan">Scan with a phone to open its app download page.</p>
+
+      <p class="help">
+        After installing, return to the original link to continue. Only your
+        public Trustroots username is carried in the link.
+      </p>
+      <a class="home" href="../../">Explore Nostroots on the web</a>
+    </main>
+
+    <script>
+      const IOS_URL = "https://apps.apple.com/app/nostroots/id6755037304";
+      const ANDROID_URL =
+        "https://play.google.com/store/apps/details?id=org.trustroots.nostroots";
+      const username = new URLSearchParams(window.location.search).get(
+        "username",
+      );
+      if (username) {
+        const usernameElement = document.getElementById("username");
+        usernameElement.textContent = `Trustroots username: ${username}`;
+        usernameElement.hidden = false;
+      }
+
+      const userAgent = navigator.userAgent || "";
+      const isIOS =
+        /iPad|iPhone|iPod/.test(userAgent) ||
+        (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+      const isAndroid = /Android/i.test(userAgent);
+
+      if (isIOS) {
+        window.location.replace(IOS_URL);
+      } else if (isAndroid) {
+        window.location.replace(ANDROID_URL);
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Add the first verified HTTPS link flow between Trustroots and the Nostroots native app:

```
https://nos.trustroots.org/open/onboarding?username=guaka
```

This gives one public URL three useful outcomes:

- with Nostroots installed, iOS Universal Links or Android App Links open the native Trustroots onboarding screen and pre-fill the username;
- without the app on Android or iPhone/iPad, the web fallback continues to Google Play or the App Store;
- on desktop or an unknown device, the fallback shows both stores, the direct Android APK releases, and the existing generic app-download QR code.

The existing `nostroots://` scheme remains available for internal and manual testing.

## What changed

### Native app

- declare `applinks:nos.trustroots.org` for iOS;
- declare verified Android HTTPS intent filters for the exact `/open/onboarding` path;
- add an Expo Router entry route at `/open/onboarding`;
- forward the optional username into `/onboarding/trustroots`;
- validate, normalize, and pre-fill that username without replacing an already-pending onboarding identity.

These declarations require a new native build; they cannot be shipped solely through an OTA update.

### Website

- publish `.well-known/apple-app-site-association` for Apple Team/app ID `WR2T34P467.org.trustroots.nostroots`;
- publish `.well-known/assetlinks.json` for `org.trustroots.nostroots`;
- add the static `/open/onboarding` fallback page;
- select the matching mobile store after the OS has declined to open an installed app;
- retain useful desktop choices: Google Play, App Store, APK releases, and the generic QR.

## Intended Trustroots flow

A logged-in member on `www.trustroots.org` can tap “Continue in Nostroots,” linking to the URL above.

1. The operating system checks the app/site association.
2. If installed, Nostroots opens Trustroots onboarding with the username filled in.
3. If absent, the browser reaches the fallback and continues to the appropriate store.
4. After installation, the member returns to the original Trustroots link and opens it again.

Using `nos.trustroots.org` for the app-opening URL also avoids iOS Safari's same-domain preference when the link originates on `www.trustroots.org`.

Adding the button on `www.trustroots.org` belongs in the separate Trustroots repository.

## Content and event links

This PR implements onboarding as the first complete vertical slice. The same verified-link family can later support specific public content with allowlisted path shapes:

```
/open/event/<event-id>?username=guaka
/open/profile/<npub>?username=guaka
/open/map/<plus-code>?username=guaka
```

The path should represent the destination; the optional username is onboarding context. We should not accept an arbitrary destination URL.

For event links, the app should:

1. parse and validate the supported destination;
2. open it immediately for an onboarded user;
3. otherwise remember it locally, run onboarding with the username pre-filled, and continue to the destination afterwards.

A content landing page should preview the event where possible. Its QR must encode the complete content URL—not the generic app download URL—so both destination and onboarding context survive scanning.

Verified links do not themselves provide reliable deferred deep linking through a first-time store installation. The first version should ask users to return to the original Trustroots link after installing. Android can optionally improve this later with Play Install Referrer. iOS does not provide an equivalent simple automatic continuation path.

The native app currently has no standalone event route, so event routing is intentionally documented as a follow-up rather than represented by a misleading generic `destination` parameter.

## Security boundary

The URL may contain public, low-sensitivity context such as a Trustroots username or public Nostr event identifier.

It must not contain:

- an nsec;
- session cookies;
- permanent API tokens;
- email verification codes;
- long-lived authenticated handoff credentials.

If Trustroots later transfers authenticated state to Nostroots, use a short-lived, single-use authorization code, ideally bound to the app with PKCE.

## Android signing rollout requirement

The committed `assetlinks.json` contains the SHA-256 certificate fingerprint extracted from the official GitHub preview APK.

Before relying on App Links for Google Play installations, add the separate fingerprint shown under:

**Play Console → Setup → App integrity → App signing key certificate**

Google Play App Signing uses a different signing certificate from the upload/direct-distribution key. Both fingerprints can coexist in `sha256_cert_fingerprints`.

## Deployment order

1. Add the Google Play app-signing fingerprint.
2. Deploy the web association files and fallback page.
3. Verify both `.well-known` responses are served over HTTPS without redirects.
4. Release new iOS and Android native builds containing the domain declarations.
5. Add “Continue in Nostroots” links on `www.trustroots.org`.
6. Test installed and not-installed paths on physical iOS and Android devices.
7. Add explicit event/profile/map native routes in follow-up PRs.

## Validation

- Full nr-app Jest suite from the push hook: **66 suites, 300 tests passed**.
- Focused onboarding/deep-link tests: **2 suites, 6 tests passed**.
- Expo configuration resolves the intended iOS associated domain and exact Android intent filters.
- Both association documents parse as valid JSON.
- The fallback's inline script parses successfully.
- `git diff --check` passes.
- The repository-wide TypeScript check currently reports existing baseline errors in unrelated files; it reports no error for the new `app/open/onboarding.tsx` route or the modified Trustroots onboarding screen.
