### PR TITLE
fix(nr-app): show the welcome screen on a fresh install

### DIFF
--- a/nr-app/.maestro/subflows/open-key-screen.yaml
+++ b/nr-app/.maestro/subflows/open-key-screen.yaml
@@ -7,15 +7,17 @@ name: Open the key step from a clean install
 - launchApp:
     clearState: true
 
-# NOTE: a fresh install lands on identity, not welcome. app/index.tsx renders
-# Redirect->WELCOME, then its own effect sets hasBeenOpenedBefore, and the
-# re-render swaps in Redirect->ONBOARDING before the first redirect navigates.
-# This encodes today's behaviour, not the intended behaviour. If the welcome
-# screen is fixed, add the welcome-get-started tap back here.
+- extendedWaitUntil:
+    visible:
+      id: "welcome-get-started"
+    timeout: 30000
+- tapOn:
+    id: "welcome-get-started"
+
 - extendedWaitUntil:
     visible:
       id: "onboarding-identity-continue"
-    timeout: 30000
+    timeout: 15000
 - tapOn:
     id: "onboarding-identity-continue"
 

--- a/nr-app/app/index.test.tsx
+++ b/nr-app/app/index.test.tsx
@@ -3,7 +3,7 @@ import { waitFor, screen } from "@testing-library/react-native";
 
 import IndexRoute from "./index";
 import { ROUTES } from "@/constants/routes";
-import { renderWithProviders } from "@/test/test-utils";
+import { flushPromises, renderWithProviders } from "@/test/test-utils";
 
 const mockRedirect = Redirect as jest.Mock;
 
@@ -41,6 +41,25 @@ describe("IndexRoute", () => {
         undefined,
       );
     });
+  });
+
+  it("leaves hasBeenOpenedBefore alone so welcome is not redirected away", async () => {
+    const { store } = renderWithProviders(<IndexRoute />, {
+      preloadedState: {
+        settings: {
+          isDataLoaded: true,
+          hasBeenOpenedBefore: false,
+        },
+      },
+    });
+
+    await flushPromises();
+
+    expect(store.getState().settings.hasBeenOpenedBefore).toBe(false);
+    expect(mockRedirect).not.toHaveBeenCalledWith(
+      { href: ROUTES.ONBOARDING },
+      undefined,
+    );
   });
 
   it("sends returning users without identity to onboarding", async () => {

--- a/nr-app/app/index.tsx
+++ b/nr-app/app/index.tsx
@@ -12,7 +12,6 @@ import {
 } from "@/redux/slices/keystore.slice";
 import {
   selectFeatureFlags,
-  settingsActions,
   settingsSelectors,
 } from "@/redux/slices/settings.slice";
 import { resolveStartupRoute } from "@/utils/startupRoute.utils";
@@ -92,13 +91,6 @@ export default function IndexRoute() {
       cancelled = true;
     };
   }, [isSettingsDataLoaded, username, npub, dispatch]);
-
-  // Mark app as opened on first redirect
-  useEffect(() => {
-    if (isSettingsDataLoaded && verificationDone && !hasBeenOpenedBefore) {
-      dispatch(settingsActions.setHasBeenOpenedBefore(true));
-    }
-  }, [isSettingsDataLoaded, verificationDone, hasBeenOpenedBefore, dispatch]);
 
   // Show loading while determining destination
   if (!isSettingsDataLoaded || !verificationDone) {

--- a/nr-app/app/welcome.test.tsx
+++ b/nr-app/app/welcome.test.tsx
@@ -1,28 +1,29 @@
-import { fireEvent, render } from "@testing-library/react-native";
-import { useRouter } from "expo-router";
+import { render, screen, userEvent } from "@testing-library/react-native";
 
+import { settingsActions } from "@/redux/slices/settings.slice";
+import { getRouterMock } from "@/test/router";
 import WelcomeScreen from "./welcome";
 
-const mockUseRouter = useRouter as jest.Mock;
+const mockDispatch = jest.fn();
+
+jest.mock("@/redux/hooks", () => ({
+  useAppDispatch: () => mockDispatch,
+}));
 
 describe("WelcomeScreen", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    mockDispatch.mockClear();
   });
 
-  it("moves users into onboarding from the welcome screen", () => {
-    const replace = jest.fn();
-    mockUseRouter.mockReturnValue({
-      push: jest.fn(),
-      replace,
-      back: jest.fn(),
-    });
+  it("records that welcome was dismissed before navigating to onboarding", async () => {
+    render(<WelcomeScreen />);
 
-    const { getByText } = render(<WelcomeScreen />);
+    expect(screen.getByText("Welcome to Nostroots")).toBeTruthy();
+    await userEvent.press(screen.getByTestId("welcome-get-started"));
 
-    expect(getByText("Welcome to Nostroots")).toBeTruthy();
-    fireEvent.press(getByText("Get Started"));
-
-    expect(replace).toHaveBeenCalledWith("/onboarding");
+    expect(mockDispatch).toHaveBeenCalledWith(
+      settingsActions.setHasBeenOpenedBefore(true),
+    );
+    expect(getRouterMock().replace).toHaveBeenCalledWith("/onboarding");
   });
 });

--- a/nr-app/app/welcome.tsx
+++ b/nr-app/app/welcome.tsx
@@ -4,12 +4,16 @@ import { View } from "react-native";
 
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
+import { useAppDispatch } from "@/redux/hooks";
+import { settingsActions } from "@/redux/slices/settings.slice";
 import { trackEvent } from "@/services/analytics.service";
 
 export default function WelcomeScreen() {
   const router = useRouter();
+  const dispatch = useAppDispatch();
 
   const handleGetStarted = () => {
+    dispatch(settingsActions.setHasBeenOpenedBefore(true));
     trackEvent("onboarding_started");
     router.replace("/onboarding");
   };


### PR DESCRIPTION
Split out of #279 so the fix can land on its own.

## The bug

`app/index.tsx` dispatched `setHasBeenOpenedBefore(true)` from an effect in the same commit that rendered `<Redirect href={WELCOME} />`. The resulting re-render swapped in `<Redirect href={ONBOARDING} />` before the first redirect had navigated, so the welcome screen never appeared on a fresh install.

## The fix

Drop that effect and set the flag in `welcome.tsx` when **Get Started** is tapped. The flag now means what `index.tsx` already assumed it meant: the user has dismissed the welcome screen.

## Tests

New unit tests: `app/index.test.tsx` (fresh install redirects to welcome, not onboarding) and `app/welcome.test.tsx` (Get Started sets the flag and navigates). The `open-key-screen` Maestro subflow is updated to step through the welcome screen that now actually shows.

`pnpm test` in `nr-app`: 21 suites / 132 tests passing.

The e2e mock stack and Maestro flows from #279 follow in a separate PR stacked on this branch.